### PR TITLE
Fix firstrunwizard

### DIFF
--- a/css/colorbox.css
+++ b/css/colorbox.css
@@ -34,5 +34,5 @@
         #cboxNext:hover{background-position:bottom right;}
         #cboxLoadingOverlay{background:#fff;}
         #cboxLoadingGraphic{background:none;}
-        #cboxClose{position:absolute; top:5px; right:5px; display:block; background:none; width:38px; height:19px; text-indent:-9999px;}
+        #cboxClose{position:absolute; top:5px; right:5px; display:block; background:none; width:38px; height:19px; text-indent:-9999px; border:none;}
         #cboxClose:hover{background-position:bottom center;}

--- a/js/firstrunwizard.js
+++ b/js/firstrunwizard.js
@@ -6,11 +6,6 @@ function showfirstrunwizard(){
 		width: '80%',
 		height: '80%',
 		href: OC.filePath('firstrunwizard', '', 'wizard.php'),
-		onComplete : function(){
-			if (!SVGSupport()) {
-				replaceSVG();
-			}
-		},
 		onClosed : function(){
 			$.ajax({
 			url: OC.filePath('firstrunwizard', 'ajax', 'disable.php'),

--- a/js/jquery.colorbox.js
+++ b/js/jquery.colorbox.js
@@ -1,128 +1,185 @@
-// ColorBox v1.3.20.2 - jQuery lightbox plugin
-// (c) 2012 Jack Moore - jacklmoore.com
-// License: http://www.opensource.org/licenses/mit-license.php
+/*!
+ Colorbox 1.6.4
+ license: MIT
+ http://www.jacklmoore.com/colorbox
+ */
 (function ($, document, window) {
 	var
-	// Default settings object.
-	// See http://jacklmoore.com/colorbox for details.
-	defaults = {
-		transition: "elastic",
-		speed: 300,
-		width: false,
-		initialWidth: "600",
-		innerWidth: false,
-		maxWidth: false,
-		height: false,
-		initialHeight: "450",
-		innerHeight: false,
-		maxHeight: false,
-		scalePhotos: true,
-		scrolling: true,
-		inline: false,
-		html: false,
-		iframe: false,
-		fastIframe: true,
-		photo: false,
-		href: false,
-		title: false,
-		rel: false,
-		opacity: 0.9,
-		preloading: true,
+		// Default settings object.
+		// See http://jacklmoore.com/colorbox for details.
+		defaults = {
+			// data sources
+			html: false,
+			photo: false,
+			iframe: false,
+			inline: false,
 
-		current: "image {current} of {total}",
-		previous: "previous",
-		next: "next",
-		close: "close",
-		xhrError: "This content failed to load.",
-		imgError: "This image failed to load.",
+			// behavior and appearance
+			transition: "elastic",
+			speed: 300,
+			fadeOut: 300,
+			width: false,
+			initialWidth: "600",
+			innerWidth: false,
+			maxWidth: false,
+			height: false,
+			initialHeight: "450",
+			innerHeight: false,
+			maxHeight: false,
+			scalePhotos: true,
+			scrolling: true,
+			opacity: 0.9,
+			preloading: true,
+			className: false,
+			overlayClose: true,
+			escKey: true,
+			arrowKey: true,
+			top: false,
+			bottom: false,
+			left: false,
+			right: false,
+			fixed: false,
+			data: undefined,
+			closeButton: true,
+			fastIframe: true,
+			open: false,
+			reposition: true,
+			loop: true,
+			slideshow: false,
+			slideshowAuto: true,
+			slideshowSpeed: 2500,
+			slideshowStart: "start slideshow",
+			slideshowStop: "stop slideshow",
+			photoRegex: /\.(gif|png|jp(e|g|eg)|bmp|ico|webp|jxr|svg)((#|\?).*)?$/i,
 
-		open: false,
-		returnFocus: true,
-		reposition: true,
-		loop: true,
-		slideshow: false,
-		slideshowAuto: true,
-		slideshowSpeed: 2500,
-		slideshowStart: "start slideshow",
-		slideshowStop: "stop slideshow",
-		onOpen: false,
-		onLoad: false,
-		onComplete: false,
-		onCleanup: false,
-		onClosed: false,
-		overlayClose: true,
-		escKey: true,
-		arrowKey: true,
-		top: false,
-		bottom: false,
-		left: false,
-		right: false,
-		fixed: false,
-		data: undefined
-	},
-	
-	// Abstracting the HTML and event identifiers for easy rebranding
-	colorbox = 'colorbox',
-	prefix = 'cbox',
-	boxElement = prefix + 'Element',
-	
-	// Events
-	event_open = prefix + '_open',
-	event_load = prefix + '_load',
-	event_complete = prefix + '_complete',
-	event_cleanup = prefix + '_cleanup',
-	event_closed = prefix + '_closed',
-	event_purge = prefix + '_purge',
-	
-	// Special Handling for IE
-	isIE = !$.support.opacity && !$.support.style, // IE7 & IE8
-	isIE6 = isIE && !window.XMLHttpRequest, // IE6
-	event_ie6 = prefix + '_IE6',
+			// alternate image paths for high-res displays
+			retinaImage: false,
+			retinaUrl: false,
+			retinaSuffix: '@2x.$1',
 
-	// Cached jQuery Object Variables
-	$overlay,
-	$box,
-	$wrap,
-	$content,
-	$topBorder,
-	$leftBorder,
-	$rightBorder,
-	$bottomBorder,
-	$related,
-	$window,
-	$loaded,
-	$loadingBay,
-	$loadingOverlay,
-	$title,
-	$current,
-	$slideshow,
-	$next,
-	$prev,
-	$close,
-	$groupControls,
-	
-	// Variables for cached values or use across multiple functions
-	settings,
-	interfaceHeight,
-	interfaceWidth,
-	loadedHeight,
-	loadedWidth,
-	element,
-	index,
-	photo,
-	open,
-	active,
-	closing,
-	loadingTimer,
-	publicMethod,
-	div = "div",
-	init;
+			// internationalization
+			current: "image {current} of {total}",
+			previous: "previous",
+			next: "next",
+			close: "close",
+			xhrError: "This content failed to load.",
+			imgError: "This image failed to load.",
+
+			// accessbility
+			returnFocus: true,
+			trapFocus: true,
+
+			// callbacks
+			onOpen: false,
+			onLoad: false,
+			onComplete: false,
+			onCleanup: false,
+			onClosed: false,
+
+			rel: function() {
+				return this.rel;
+			},
+			href: function() {
+				// using this.href would give the absolute url, when the href may have been inteded as a selector (e.g. '#container')
+				return $(this).attr('href');
+			},
+			title: function() {
+				return this.title;
+			},
+			createImg: function() {
+				var img = new Image();
+				var attrs = $(this).data('cbox-img-attrs');
+
+				if (typeof attrs === 'object') {
+					$.each(attrs, function(key, val){
+						img[key] = val;
+					});
+				}
+
+				return img;
+			},
+			createIframe: function() {
+				var iframe = document.createElement('iframe');
+				var attrs = $(this).data('cbox-iframe-attrs');
+
+				if (typeof attrs === 'object') {
+					$.each(attrs, function(key, val){
+						iframe[key] = val;
+					});
+				}
+
+				if ('frameBorder' in iframe) {
+					iframe.frameBorder = 0;
+				}
+				if ('allowTransparency' in iframe) {
+					iframe.allowTransparency = "true";
+				}
+				iframe.name = (new Date()).getTime(); // give the iframe a unique name to prevent caching
+				iframe.allowFullscreen = true;
+
+				return iframe;
+			}
+		},
+
+		// Abstracting the HTML and event identifiers for easy rebranding
+		colorbox = 'colorbox',
+		prefix = 'cbox',
+		boxElement = prefix + 'Element',
+
+		// Events
+		event_open = prefix + '_open',
+		event_load = prefix + '_load',
+		event_complete = prefix + '_complete',
+		event_cleanup = prefix + '_cleanup',
+		event_closed = prefix + '_closed',
+		event_purge = prefix + '_purge',
+
+		// Cached jQuery Object Variables
+		$overlay,
+		$box,
+		$wrap,
+		$content,
+		$topBorder,
+		$leftBorder,
+		$rightBorder,
+		$bottomBorder,
+		$related,
+		$window,
+		$loaded,
+		$loadingBay,
+		$loadingOverlay,
+		$title,
+		$current,
+		$slideshow,
+		$next,
+		$prev,
+		$close,
+		$groupControls,
+		$events = $('<a/>'), // $({}) would be prefered, but there is an issue with jQuery 1.4.2
+
+		// Variables for cached values or use across multiple functions
+		settings,
+		interfaceHeight,
+		interfaceWidth,
+		loadedHeight,
+		loadedWidth,
+		index,
+		photo,
+		open,
+		active,
+		closing,
+		loadingTimer,
+		publicMethod,
+		div = "div",
+		requests = 0,
+		previousCSS = {},
+		init;
 
 	// ****************
 	// HELPER FUNCTIONS
 	// ****************
-	
-	// Convience function for creating new jQuery objects
+
+	// Convenience function for creating new jQuery objects
 	function $tag(tag, id, css) {
 		var element = document.createElement(tag);
 
@@ -137,200 +194,303 @@
 		return $(element);
 	}
 
+	// Get the window height using innerHeight when available to avoid an issue with iOS
+	// http://bugs.jquery.com/ticket/6724
+	function winheight() {
+		return window.innerHeight ? window.innerHeight : $(window).height();
+	}
+
+	function Settings(element, options) {
+		if (options !== Object(options)) {
+			options = {};
+		}
+
+		this.cache = {};
+		this.el = element;
+
+		this.value = function(key) {
+			var dataAttr;
+
+			if (this.cache[key] === undefined) {
+				dataAttr = $(this.el).attr('data-cbox-'+key);
+
+				if (dataAttr !== undefined) {
+					this.cache[key] = dataAttr;
+				} else if (options[key] !== undefined) {
+					this.cache[key] = options[key];
+				} else if (defaults[key] !== undefined) {
+					this.cache[key] = defaults[key];
+				}
+			}
+
+			return this.cache[key];
+		};
+
+		this.get = function(key) {
+			var value = this.value(key);
+			return $.isFunction(value) ? value.call(this.el, this) : value;
+		};
+	}
+
 	// Determine the next and previous members in a group.
 	function getIndex(increment) {
 		var
-		max = $related.length,
-		newIndex = (index + increment) % max;
-		
+			max = $related.length,
+			newIndex = (index + increment) % max;
+
 		return (newIndex < 0) ? max + newIndex : newIndex;
 	}
 
 	// Convert '%' and 'px' values to integers
 	function setSize(size, dimension) {
-		return Math.round((/%/.test(size) ? ((dimension === 'x' ? $window.width() : $window.height()) / 100) : 1) * parseInt(size, 10));
+		return Math.round((/%/.test(size) ? ((dimension === 'x' ? $window.width() : winheight()) / 100) : 1) * parseInt(size, 10));
 	}
-	
+
 	// Checks an href to see if it is a photo.
-	// There is a force photo option (photo: true) for hrefs that cannot be matched by this regex.
-	function isImage(url) {
-		return settings.photo || /\.(gif|png|jp(e|g|eg)|bmp|ico)((#|\?).*)?$/i.test(url);
+	// There is a force photo option (photo: true) for hrefs that cannot be matched by the regex.
+	function isImage(settings, url) {
+		return settings.get('photo') || settings.get('photoRegex').test(url);
 	}
 
-	// Assigns function results to their respective properties
-	function makeSettings() {
-		var i,
-			data = $.data(element, colorbox);
-		
-		if (data == null) {
-			settings = $.extend({}, defaults);
-			if (console && console.log) {
-				console.log('Error: cboxElement missing settings object');
+	function retinaUrl(settings, url) {
+		return settings.get('retinaUrl') && window.devicePixelRatio > 1 ? url.replace(settings.get('photoRegex'), settings.get('retinaSuffix')) : url;
+	}
+
+	function trapFocus(e) {
+		if ('contains' in $box[0] && !$box[0].contains(e.target) && e.target !== $overlay[0]) {
+			e.stopPropagation();
+			$box.focus();
+		}
+	}
+
+	function setClass(str) {
+		if (setClass.str !== str) {
+			$box.add($overlay).removeClass(setClass.str).addClass(str);
+			setClass.str = str;
+		}
+	}
+
+	function getRelated(rel) {
+		index = 0;
+
+		if (rel && rel !== false && rel !== 'nofollow') {
+			$related = $('.' + boxElement).filter(function () {
+				var options = $.data(this, colorbox);
+				var settings = new Settings(this, options);
+				return (settings.get('rel') === rel);
+			});
+			index = $related.index(settings.el);
+
+			// Check direct calls to Colorbox.
+			if (index === -1) {
+				$related = $related.add(settings.el);
+				index = $related.length - 1;
 			}
 		} else {
-			settings = $.extend({}, data);
-		}
-		
-		for (i in settings) {
-			if ($.isFunction(settings[i]) && i.slice(0, 2) !== 'on') { // checks to make sure the function isn't one of the callbacks, they will be handled at the appropriate time.
-				settings[i] = settings[i].call(element);
-			}
-		}
-		
-		settings.rel = settings.rel || element.rel || $(element).data('rel') || 'nofollow';
-		settings.href = settings.href || $(element).attr('href');
-		settings.title = settings.title || element.title;
-		
-		if (typeof settings.href === "string") {
-			settings.href = $.trim(settings.href);
+			$related = $(settings.el);
 		}
 	}
 
-	function trigger(event, callback) {
-		$.event.trigger(event);
-		if (callback) {
-			callback.call(element);
-		}
+	function trigger(event) {
+		// for external use
+		$(document).trigger(event);
+		// for internal use
+		$events.triggerHandler(event);
 	}
 
-	// Slideshow functionality
-	function slideshow() {
-		var
-		timeOut,
-		className = prefix + "Slideshow_",
-		click = "click." + prefix,
-		start,
-		stop;
-		
-		if (settings.slideshow && $related[1]) {
-			start = function () {
-				$slideshow
-					.html(settings.slideshowStop)
-					.unbind(click)
-					.bind(event_complete, function () {
-						if (settings.loop || $related[index + 1]) {
-							timeOut = setTimeout(publicMethod.next, settings.slideshowSpeed);
-						}
-					})
-					.bind(event_load, function () {
-						clearTimeout(timeOut);
-					})
-					.one(click + ' ' + event_cleanup, stop);
-				$box.removeClass(className + "off").addClass(className + "on");
-				timeOut = setTimeout(publicMethod.next, settings.slideshowSpeed);
-			};
-			
-			stop = function () {
-				clearTimeout(timeOut);
-				$slideshow
-					.html(settings.slideshowStart)
-					.unbind([event_complete, event_load, event_cleanup, click].join(' '))
-					.one(click, function () {
-						publicMethod.next();
-						start();
-					});
-				$box.removeClass(className + "on").addClass(className + "off");
-			};
-			
-			if (settings.slideshowAuto) {
-				start();
-			} else {
-				stop();
+	var slideshow = (function(){
+		var active,
+			className = prefix + "Slideshow_",
+			click = "click." + prefix,
+			timeOut;
+
+		function clear () {
+			clearTimeout(timeOut);
+		}
+
+		function set() {
+			if (settings.get('loop') || $related[index + 1]) {
+				clear();
+				timeOut = setTimeout(publicMethod.next, settings.get('slideshowSpeed'));
 			}
-		} else {
+		}
+
+		function start() {
+			$slideshow
+				.html(settings.get('slideshowStop'))
+				.unbind(click)
+				.one(click, stop);
+
+			$events
+				.bind(event_complete, set)
+				.bind(event_load, clear);
+
+			$box.removeClass(className + "off").addClass(className + "on");
+		}
+
+		function stop() {
+			clear();
+
+			$events
+				.unbind(event_complete, set)
+				.unbind(event_load, clear);
+
+			$slideshow
+				.html(settings.get('slideshowStart'))
+				.unbind(click)
+				.one(click, function () {
+					publicMethod.next();
+					start();
+				});
+
+			$box.removeClass(className + "on").addClass(className + "off");
+		}
+
+		function reset() {
+			active = false;
+			$slideshow.hide();
+			clear();
+			$events
+				.unbind(event_complete, set)
+				.unbind(event_load, clear);
 			$box.removeClass(className + "off " + className + "on");
 		}
-	}
 
-	function launch(target) {
-		if (!closing) {
-			
-			element = target;
-			
-			makeSettings();
-			
-			$related = $(element);
-			
-			index = 0;
-			
-			if (settings.rel !== 'nofollow') {
-				$related = $('.' + boxElement).filter(function () {
-					var data = $.data(this, colorbox),
-						relRelated;
-
-					if (data) {
-						relRelated =  $(this).data('rel') || data.rel || this.rel;
+		return function(){
+			if (active) {
+				if (!settings.get('slideshow')) {
+					$events.unbind(event_cleanup, reset);
+					reset();
+				}
+			} else {
+				if (settings.get('slideshow') && $related[1]) {
+					active = true;
+					$events.one(event_cleanup, reset);
+					if (settings.get('slideshowAuto')) {
+						start();
+					} else {
+						stop();
 					}
-					
-					return (relRelated === settings.rel);
-				});
-				index = $related.index(element);
-				
-				// Check direct calls to ColorBox.
-				if (index === -1) {
-					$related = $related.add(element);
-					index = $related.length - 1;
+					$slideshow.show();
 				}
 			}
-			
+		};
+
+	}());
+
+
+	function launch(element) {
+		var options;
+
+		if (!closing) {
+
+			options = $(element).data(colorbox);
+
+			settings = new Settings(element, options);
+
+			getRelated(settings.get('rel'));
+
 			if (!open) {
 				open = active = true; // Prevents the page-change action from queuing up if the visitor holds down the left or right keys.
-				
-				$box.show();
-				
-				if (settings.returnFocus) {
-					$(element).blur().one(event_closed, function () {
-						$(this).focus();
+
+				setClass(settings.get('className'));
+
+				// Show colorbox so the sizes can be calculated in older versions of jQuery
+				$box.css({visibility:'hidden', display:'block', opacity:''});
+
+				$loaded = $tag(div, 'LoadedContent', 'width:0; height:0; overflow:hidden; visibility:hidden');
+				$content.css({width:'', height:''}).append($loaded);
+
+				// Cache values needed for size calculations
+				interfaceHeight = $topBorder.height() + $bottomBorder.height() + $content.outerHeight(true) - $content.height();
+				interfaceWidth = $leftBorder.width() + $rightBorder.width() + $content.outerWidth(true) - $content.width();
+				loadedHeight = $loaded.outerHeight(true);
+				loadedWidth = $loaded.outerWidth(true);
+
+				// Opens inital empty Colorbox prior to content being loaded.
+				var initialWidth = setSize(settings.get('initialWidth'), 'x');
+				var initialHeight = setSize(settings.get('initialHeight'), 'y');
+				var maxWidth = settings.get('maxWidth');
+				var maxHeight = settings.get('maxHeight');
+
+				settings.w = Math.max((maxWidth !== false ? Math.min(initialWidth, setSize(maxWidth, 'x')) : initialWidth) - loadedWidth - interfaceWidth, 0);
+				settings.h = Math.max((maxHeight !== false ? Math.min(initialHeight, setSize(maxHeight, 'y')) : initialHeight) - loadedHeight - interfaceHeight, 0);
+
+				$loaded.css({width:'', height:settings.h});
+				publicMethod.position();
+
+				trigger(event_open);
+				settings.get('onOpen');
+
+				$groupControls.add($title).hide();
+
+				$box.focus();
+
+				if (settings.get('trapFocus')) {
+					// Confine focus to the modal
+					// Uses event capturing that is not supported in IE8-
+					if (document.addEventListener) {
+
+						document.addEventListener('focus', trapFocus, true);
+
+						$events.one(event_closed, function () {
+							document.removeEventListener('focus', trapFocus, true);
+						});
+					}
+				}
+
+				// Return focus on closing
+				if (settings.get('returnFocus')) {
+					$events.one(event_closed, function () {
+						$(settings.el).focus();
 					});
 				}
-				
-				// +settings.opacity avoids a problem in IE when using non-zero-prefixed-string-values, like '.5'
-				$overlay.css({"opacity": +settings.opacity, "cursor": settings.overlayClose ? "pointer" : "auto"}).show();
-				
-				// Opens inital empty ColorBox prior to content being loaded.
-				settings.w = setSize(settings.initialWidth, 'x');
-				settings.h = setSize(settings.initialHeight, 'y');
-				publicMethod.position();
-				
-				if (isIE6) {
-					$window.bind('resize.' + event_ie6 + ' scroll.' + event_ie6, function () {
-						$overlay.css({width: $window.width(), height: $window.height(), top: $window.scrollTop(), left: $window.scrollLeft()});
-					}).trigger('resize.' + event_ie6);
-				}
-				
-				trigger(event_open, settings.onOpen);
-				
-				$groupControls.add($title).hide();
-				
-				$close.html(settings.close).show();
 			}
-			
-			publicMethod.load(true);
+
+			var opacity = parseFloat(settings.get('opacity'));
+			$overlay.css({
+				opacity: opacity === opacity ? opacity : '',
+				cursor: settings.get('overlayClose') ? 'pointer' : '',
+				visibility: 'visible'
+			}).show();
+
+			if (settings.get('closeButton')) {
+				$close.html(settings.get('close')).appendTo($content);
+			} else {
+				$close.appendTo('<div/>'); // replace with .detach() when dropping jQuery < 1.4
+			}
+
+			load();
 		}
 	}
 
-	// ColorBox's markup needs to be added to the DOM prior to being called
+	// Colorbox's markup needs to be added to the DOM prior to being called
 	// so that the browser will go ahead and load the CSS background images.
 	function appendHTML() {
-		if (!$box && document.body) {
+		if (!$box) {
 			init = false;
-
 			$window = $(window);
-			$box = $tag(div).attr({id: colorbox, 'class': isIE ? prefix + (isIE6 ? 'IE6' : 'IE') : ''}).hide();
-			$overlay = $tag(div, "Overlay", isIE6 ? 'position:absolute' : '').hide();
-			$loadingOverlay = $tag(div, "LoadingOverlay").add($tag(div, "LoadingGraphic"));
+			$box = $tag(div).attr({
+				id: colorbox,
+				'class': $.support.opacity === false ? prefix + 'IE' : '', // class for optional IE8 & lower targeted CSS.
+				role: 'dialog',
+				tabindex: '-1'
+			}).hide();
+			$overlay = $tag(div, "Overlay").hide();
+			$loadingOverlay = $([$tag(div, "LoadingOverlay")[0],$tag(div, "LoadingGraphic")[0]]);
 			$wrap = $tag(div, "Wrapper");
 			$content = $tag(div, "Content").append(
-				$loaded = $tag(div, "LoadedContent", 'width:0; height:0; overflow:hidden'),
 				$title = $tag(div, "Title"),
 				$current = $tag(div, "Current"),
-				$next = $tag(div, "Next"),
-				$prev = $tag(div, "Previous"),
-				$slideshow = $tag(div, "Slideshow").bind(event_open, slideshow),
-				$close = $tag(div, "Close")
+				$prev = $('<button type="button"/>').attr({id:prefix+'Previous'}),
+				$next = $('<button type="button"/>').attr({id:prefix+'Next'}),
+				$slideshow = $('<button type="button"/>').attr({id:prefix+'Slideshow'}),
+				$loadingOverlay
 			);
-			
-			$wrap.append( // The 3x3 Grid that makes up ColorBox
+
+			$close = $('<button type="button"/>').attr({id:prefix+'Close'});
+
+			$wrap.append( // The 3x3 Grid that makes up Colorbox
 				$tag(div).append(
 					$tag(div, "TopLeft"),
 					$topBorder = $tag(div, "TopCenter"),
@@ -347,29 +507,30 @@
 					$tag(div, "BottomRight")
 				)
 			).find('div div').css({'float': 'left'});
-			
-			$loadingBay = $tag(div, false, 'position:absolute; width:9999px; visibility:hidden; display:none');
-			
-			$groupControls = $next.add($prev).add($current).add($slideshow);
 
+			$loadingBay = $tag(div, false, 'position:absolute; width:9999px; visibility:hidden; display:none; max-width:none;');
+
+			$groupControls = $next.add($prev).add($current).add($slideshow);
+		}
+		if (document.body && !$box.parent().length) {
 			$(document.body).append($overlay, $box.append($wrap, $loadingBay));
 		}
 	}
 
-	// Add ColorBox's event bindings
+	// Add Colorbox's event bindings
 	function addBindings() {
+		function clickHandler(e) {
+			// ignore non-left-mouse-clicks and clicks modified with ctrl / command, shift, or alt.
+			// See: http://jacklmoore.com/notes/click-events/
+			if (!(e.which > 1 || e.shiftKey || e.altKey || e.metaKey || e.ctrlKey)) {
+				e.preventDefault();
+				launch(this);
+			}
+		}
+
 		if ($box) {
 			if (!init) {
 				init = true;
-
-				// Cache values needed for size calculations
-				interfaceHeight = $topBorder.height() + $bottomBorder.height() + $content.outerHeight(true) - $content.height();//Subtraction needed for IE6
-				interfaceWidth = $leftBorder.width() + $rightBorder.width() + $content.outerWidth(true) - $content.width();
-				loadedHeight = $loaded.outerHeight(true);
-				loadedWidth = $loaded.outerWidth(true);
-				
-				// Setting padding to remove the need to do size conversions during the animation step.
-				$box.css({"padding-bottom": interfaceHeight, "padding-right": interfaceWidth});
 
 				// Anonymous functions here keep the public method from being cached, thereby allowing them to be redefined on the fly.
 				$next.click(function () {
@@ -382,19 +543,19 @@
 					publicMethod.close();
 				});
 				$overlay.click(function () {
-					if (settings.overlayClose) {
+					if (settings.get('overlayClose')) {
 						publicMethod.close();
 					}
 				});
-				
+
 				// Key Bindings
 				$(document).bind('keydown.' + prefix, function (e) {
 					var key = e.keyCode;
-					if (open && settings.escKey && key === 27) {
+					if (open && settings.get('escKey') && key === 27) {
 						e.preventDefault();
 						publicMethod.close();
 					}
-					if (open && settings.arrowKey && $related[1]) {
+					if (open && settings.get('arrowKey') && $related[1] && !e.altKey) {
 						if (key === 37) {
 							e.preventDefault();
 							$prev.click();
@@ -405,22 +566,23 @@
 					}
 				});
 
-				$(document).delegate('.'+boxElement, 'click', function(e) {
-					// ignore non-left-mouse-clicks and clicks modified with ctrl / command, shift, or alt.
-					// See: http://jacklmoore.com/notes/click-events/
-					if (!(e.which > 1 || e.shiftKey || e.altKey || e.metaKey)) {
-						e.preventDefault();
-						launch(this);
-					}
-				});
+				if ($.isFunction($.fn.on)) {
+					// For jQuery 1.7+
+					$(document).on('click.'+prefix, '.'+boxElement, clickHandler);
+				} else {
+					// For jQuery 1.3.x -> 1.6.x
+					// This code is never reached in jQuery 1.9, so do not contact me about 'live' being removed.
+					// This is not here for jQuery 1.9, it's here for legacy users.
+					$('.'+boxElement).live('click.'+prefix, clickHandler);
+				}
 			}
 			return true;
 		}
 		return false;
 	}
 
-	// Don't do anything if ColorBox already exists.
-	if ($.colorbox) {
+	// Don't do anything if Colorbox already exists.
+	if ($[colorbox]) {
 		return;
 	}
 
@@ -430,52 +592,57 @@
 
 	// ****************
 	// PUBLIC FUNCTIONS
-	// Usage format: $.fn.colorbox.close();
-	// Usage from within an iframe: parent.$.fn.colorbox.close();
+	// Usage format: $.colorbox.close();
+	// Usage from within an iframe: parent.jQuery.colorbox.close();
 	// ****************
-	
+
 	publicMethod = $.fn[colorbox] = $[colorbox] = function (options, callback) {
-		var $this = this;
-		
+		var settings;
+		var $obj = this;
+
 		options = options || {};
-		
+
+		if ($.isFunction($obj)) { // assume a call to $.colorbox
+			$obj = $('<a/>');
+			options.open = true;
+		}
+
+		if (!$obj[0]) { // colorbox being applied to empty collection
+			return $obj;
+		}
+
 		appendHTML();
 
 		if (addBindings()) {
-			if (!$this[0]) {
-				if ($this.selector) { // if a selector was given and it didn't match any elements, go ahead and exit.
-					return $this;
-				}
-				// if no selector was given (ie. $.colorbox()), create a temporary element to work with
-				$this = $('<a/>');
-				options.open = true; // assume an immediate open
-			}
-			
+
 			if (callback) {
 				options.onComplete = callback;
 			}
-			
-			$this.each(function () {
-				$.data(this, colorbox, $.extend({}, $.data(this, colorbox) || defaults, options));
+
+			$obj.each(function () {
+				var old = $.data(this, colorbox) || {};
+				$.data(this, colorbox, $.extend(old, options));
 			}).addClass(boxElement);
-			
-			if (($.isFunction(options.open) && options.open.call($this)) || options.open) {
-				launch($this[0]);
+
+			settings = new Settings($obj[0], options);
+
+			if (settings.get('open')) {
+				launch($obj[0]);
 			}
 		}
-		
-		return $this;
+
+		return $obj;
 	};
 
 	publicMethod.position = function (speed, loadedCallback) {
 		var
-		css,
-		top = 0,
-		left = 0,
-		offset = $box.offset(),
-		scrollTop,
-		scrollLeft;
-		
+			css,
+			top = 0,
+			left = 0,
+			offset = $box.offset(),
+			scrollTop,
+			scrollLeft;
+
 		$window.unbind('resize.' + prefix);
 
 		// remove the modal so that it doesn't influence the document width/height
@@ -484,7 +651,7 @@
 		scrollTop = $window.scrollTop();
 		scrollLeft = $window.scrollLeft();
 
-		if (settings.fixed && !isIE6) {
+		if (settings.get('fixed')) {
 			offset.top -= scrollTop;
 			offset.left -= scrollLeft;
 			$box.css({position: 'fixed'});
@@ -495,93 +662,116 @@
 		}
 
 		// keeps the top and left positions within the browser's viewport.
-		if (settings.right !== false) {
-			left += Math.max($window.width() - settings.w - loadedWidth - interfaceWidth - setSize(settings.right, 'x'), 0);
-		} else if (settings.left !== false) {
-			left += setSize(settings.left, 'x');
+		if (settings.get('right') !== false) {
+			left += Math.max($window.width() - settings.w - loadedWidth - interfaceWidth - setSize(settings.get('right'), 'x'), 0);
+		} else if (settings.get('left') !== false) {
+			left += setSize(settings.get('left'), 'x');
 		} else {
 			left += Math.round(Math.max($window.width() - settings.w - loadedWidth - interfaceWidth, 0) / 2);
 		}
-		
-		if (settings.bottom !== false) {
-			top += Math.max($window.height() - settings.h - loadedHeight - interfaceHeight - setSize(settings.bottom, 'y'), 0);
-		} else if (settings.top !== false) {
-			top += setSize(settings.top, 'y');
+
+		if (settings.get('bottom') !== false) {
+			top += Math.max(winheight() - settings.h - loadedHeight - interfaceHeight - setSize(settings.get('bottom'), 'y'), 0);
+		} else if (settings.get('top') !== false) {
+			top += setSize(settings.get('top'), 'y');
 		} else {
-			top += Math.round(Math.max($window.height() - settings.h - loadedHeight - interfaceHeight, 0) / 2);
+			top += Math.round(Math.max(winheight() - settings.h - loadedHeight - interfaceHeight, 0) / 2);
 		}
 
-		$box.css({top: offset.top, left: offset.left});
+		$box.css({top: offset.top, left: offset.left, visibility:'visible'});
 
-		// setting the speed to 0 to reduce the delay between same-sized content.
-		speed = ($box.width() === settings.w + loadedWidth && $box.height() === settings.h + loadedHeight) ? 0 : speed || 0;
-		
 		// this gives the wrapper plenty of breathing room so it's floated contents can move around smoothly,
 		// but it has to be shrank down around the size of div#colorbox when it's done.  If not,
 		// it can invoke an obscure IE bug when using iframes.
 		$wrap[0].style.width = $wrap[0].style.height = "9999px";
-		
-		function modalDimensions(that) {
-			$topBorder[0].style.width = $bottomBorder[0].style.width = $content[0].style.width = that.style.width;
-			$content[0].style.height = $leftBorder[0].style.height = $rightBorder[0].style.height = that.style.height;
+
+		function modalDimensions() {
+			$topBorder[0].style.width = $bottomBorder[0].style.width = $content[0].style.width = (parseInt($box[0].style.width,10) - interfaceWidth)+'px';
+			$content[0].style.height = $leftBorder[0].style.height = $rightBorder[0].style.height = (parseInt($box[0].style.height,10) - interfaceHeight)+'px';
 		}
 
-		css = {width: settings.w + loadedWidth, height: settings.h + loadedHeight, top: top, left: left};
-		if(speed===0){ // temporary workaround to side-step jQuery-UI 1.8 bug (http://bugs.jquery.com/ticket/12273)
+		css = {width: settings.w + loadedWidth + interfaceWidth, height: settings.h + loadedHeight + interfaceHeight, top: top, left: left};
+
+		// setting the speed to 0 if the content hasn't changed size or position
+		if (speed) {
+			var tempSpeed = 0;
+			$.each(css, function(i){
+				if (css[i] !== previousCSS[i]) {
+					tempSpeed = speed;
+					return;
+				}
+			});
+			speed = tempSpeed;
+		}
+
+		previousCSS = css;
+
+		if (!speed) {
 			$box.css(css);
 		}
+
 		$box.dequeue().animate(css, {
-			duration: speed,
+			duration: speed || 0,
 			complete: function () {
-				modalDimensions(this);
-				
+				modalDimensions();
+
 				active = false;
-				
+
 				// shrink the wrapper down to exactly the size of colorbox to avoid a bug in IE's iframe implementation.
 				$wrap[0].style.width = (settings.w + loadedWidth + interfaceWidth) + "px";
 				$wrap[0].style.height = (settings.h + loadedHeight + interfaceHeight) + "px";
-				
-				if (settings.reposition) {
+
+				if (settings.get('reposition')) {
 					setTimeout(function () {  // small delay before binding onresize due to an IE8 bug.
 						$window.bind('resize.' + prefix, publicMethod.position);
 					}, 1);
 				}
 
-				if (loadedCallback) {
+				if ($.isFunction(loadedCallback)) {
 					loadedCallback();
 				}
 			},
-			step: function () {
-				modalDimensions(this);
-			}
+			step: modalDimensions
 		});
 	};
 
 	publicMethod.resize = function (options) {
+		var scrolltop;
+
 		if (open) {
 			options = options || {};
-			
+
 			if (options.width) {
 				settings.w = setSize(options.width, 'x') - loadedWidth - interfaceWidth;
 			}
+
 			if (options.innerWidth) {
 				settings.w = setSize(options.innerWidth, 'x');
 			}
+
 			$loaded.css({width: settings.w});
-			
+
 			if (options.height) {
 				settings.h = setSize(options.height, 'y') - loadedHeight - interfaceHeight;
 			}
+
 			if (options.innerHeight) {
 				settings.h = setSize(options.innerHeight, 'y');
 			}
+
 			if (!options.innerHeight && !options.height) {
+				scrolltop = $loaded.scrollTop();
 				$loaded.css({height: "auto"});
 				settings.h = $loaded.height();
 			}
+
 			$loaded.css({height: settings.h});
-			
-			publicMethod.position(settings.transition === "none" ? 0 : settings.speed);
+
+			if(scrolltop) {
+				$loaded.scrollTop(scrolltop);
+			}
+
+			publicMethod.position(settings.get('transition') === "none" ? 0 : settings.get('speed'));
 		}
 	};
 
@@ -589,12 +779,13 @@
 		if (!open) {
 			return;
 		}
-		
-		var callback, speed = settings.transition === "none" ? 0 : settings.speed;
-		
+
+		var callback, speed = settings.get('transition') === "none" ? 0 : settings.get('speed');
+
 		$loaded.remove();
+
 		$loaded = $tag(div, 'LoadedContent').append(object);
-		
+
 		function getWidth() {
 			settings.w = settings.w || $loaded.width();
 			settings.w = settings.mw && settings.mw < settings.w ? settings.mw : settings.w;
@@ -605,152 +796,111 @@
 			settings.h = settings.mh && settings.mh < settings.h ? settings.mh : settings.h;
 			return settings.h;
 		}
-		
+
 		$loaded.hide()
-		.appendTo($loadingBay.show())// content has to be appended to the DOM for accurate size calculations.
-		.css({width: getWidth(), overflow: settings.scrolling ? 'auto' : 'hidden'})
-		.css({height: getHeight()})// sets the height independently from the width in case the new width influences the value of height.
-		.prependTo($content);
-		
+			.appendTo($loadingBay.show())// content has to be appended to the DOM for accurate size calculations.
+			.css({width: getWidth(), overflow: settings.get('scrolling') ? 'auto' : 'hidden'})
+			.css({height: getHeight()})// sets the height independently from the width in case the new width influences the value of height.
+			.prependTo($content);
+
 		$loadingBay.hide();
-		
+
 		// floating the IMG removes the bottom line-height and fixed a problem where IE miscalculates the width of the parent element as 100% of the document width.
-		//$(photo).css({'float': 'none', marginLeft: 'auto', marginRight: 'auto'});
-		
+
 		$(photo).css({'float': 'none'});
-		
-		// Hides SELECT elements in IE6 because they would otherwise sit on top of the overlay.
-		if (isIE6) {
-			$('select').not($box.find('select')).filter(function () {
-				return this.style.visibility !== 'hidden';
-			}).css({'visibility': 'hidden'}).one(event_cleanup, function () {
-				this.style.visibility = 'inherit';
-			});
-		}
-		
+
+		setClass(settings.get('className'));
+
 		callback = function () {
-			var preload,
-				i,
-				total = $related.length,
+			var total = $related.length,
 				iframe,
-				frameBorder = 'frameBorder',
-				allowTransparency = 'allowTransparency',
-				complete,
-				src,
-				img,
-				data;
-			
+				complete;
+
 			if (!open) {
 				return;
 			}
-			
-			function removeFilter() {
-				if (isIE) {
+
+			function removeFilter() { // Needed for IE8 in versions of jQuery prior to 1.7.2
+				if ($.support.opacity === false) {
 					$box[0].style.removeAttribute('filter');
 				}
 			}
-			
+
 			complete = function () {
 				clearTimeout(loadingTimer);
-				// Detaching forces Andriod stock browser to redraw the area underneat the loading overlay.  Hiding alone isn't enough.
-				$loadingOverlay.detach().hide();
-				trigger(event_complete, settings.onComplete);
+				$loadingOverlay.hide();
+				trigger(event_complete);
+				settings.get('onComplete');
 			};
-			
-			if (isIE) {
-				//This fadeIn helps the bicubic resampling to kick-in.
-				if (photo) {
-					$loaded.fadeIn(100);
-				}
-			}
-			
-			$title.html(settings.title).add($loaded).show();
-			
-			if (total > 1) { // handle grouping
-				if (typeof settings.current === "string") {
-					$current.html(settings.current.replace('{current}', index + 1).replace('{total}', total)).show();
-				}
-				
-				$next[(settings.loop || index < total - 1) ? "show" : "hide"]().html(settings.next);
-				$prev[(settings.loop || index) ? "show" : "hide"]().html(settings.previous);
-				
-				if (settings.slideshow) {
-					$slideshow.show();
-				}
-				
-				// Preloads images within a rel group
-				if (settings.preloading) {
-					preload = [
-						getIndex(-1),
-						getIndex(1)
-					];
-					while (i = $related[preload.pop()]) {
-						data = $.data(i, colorbox);
-						
-						if (data && data.href) {
-							src = data.href;
-							if ($.isFunction(src)) {
-								src = src.call(i);
-							}
-						} else {
-							src = i.href;
-						}
 
-						if (isImage(src)) {
-							img = new Image();
+
+			$title.html(settings.get('title')).show();
+			$loaded.show();
+
+			if (total > 1) { // handle grouping
+				if (typeof settings.get('current') === "string") {
+					$current.html(settings.get('current').replace('{current}', index + 1).replace('{total}', total)).show();
+				}
+
+				$next[(settings.get('loop') || index < total - 1) ? "show" : "hide"]().html(settings.get('next'));
+				$prev[(settings.get('loop') || index) ? "show" : "hide"]().html(settings.get('previous'));
+
+				slideshow();
+
+				// Preloads images within a rel group
+				if (settings.get('preloading')) {
+					$.each([getIndex(-1), getIndex(1)], function(){
+						var img,
+							i = $related[this],
+							settings = new Settings(i, $.data(i, colorbox)),
+							src = settings.get('href');
+
+						if (src && isImage(settings, src)) {
+							src = retinaUrl(settings, src);
+							img = document.createElement('img');
 							img.src = src;
 						}
-					}
+					});
 				}
 			} else {
 				$groupControls.hide();
 			}
-			
-			if (settings.iframe) {
-				iframe = $tag('iframe')[0];
-				
-				if (frameBorder in iframe) {
-					iframe[frameBorder] = 0;
-				}
-				
-				if (allowTransparency in iframe) {
-					iframe[allowTransparency] = "true";
-				}
 
-				if (!settings.scrolling) {
+			if (settings.get('iframe')) {
+
+				iframe = settings.get('createIframe');
+
+				if (!settings.get('scrolling')) {
 					iframe.scrolling = "no";
 				}
-				
+
 				$(iframe)
 					.attr({
-						src: settings.href,
-						name: (new Date()).getTime(), // give the iframe a unique name to prevent caching
-						'class': prefix + 'Iframe',
-						allowFullScreen : true, // allow HTML5 video to go fullscreen
-						webkitAllowFullScreen : true,
-						mozallowfullscreen : true
+						src: settings.get('href'),
+						'class': prefix + 'Iframe'
 					})
 					.one('load', complete)
-					.one(event_purge, function () {
-						iframe.src = "//about:blank";
-					})
 					.appendTo($loaded);
-				
-				if (settings.fastIframe) {
+
+				$events.one(event_purge, function () {
+					iframe.src = "//about:blank";
+				});
+
+				if (settings.get('fastIframe')) {
 					$(iframe).trigger('load');
 				}
 			} else {
 				complete();
 			}
-			
-			if (settings.transition === 'fade') {
+
+			if (settings.get('transition') === 'fade') {
 				$box.fadeTo(speed, 1, removeFilter);
 			} else {
 				removeFilter();
 			}
 		};
-		
-		if (settings.transition === 'fade') {
+
+		if (settings.get('transition') === 'fade') {
 			$box.fadeTo(speed, 0, function () {
 				publicMethod.position(0, callback);
 			});
@@ -759,182 +909,195 @@
 		}
 	};
 
-	publicMethod.load = function (launched) {
-		var href, setResize, prep = publicMethod.prep;
-		
+	function load () {
+		var href, setResize, prep = publicMethod.prep, $inline, request = ++requests;
+
 		active = true;
-		
+
 		photo = false;
-		
-		element = $related[index];
-		
-		if (!launched) {
-			makeSettings();
-		}
-		
+
 		trigger(event_purge);
-		
-		trigger(event_load, settings.onLoad);
-		
-		settings.h = settings.height ?
-				setSize(settings.height, 'y') - loadedHeight - interfaceHeight :
-				settings.innerHeight && setSize(settings.innerHeight, 'y');
-		
-		settings.w = settings.width ?
-				setSize(settings.width, 'x') - loadedWidth - interfaceWidth :
-				settings.innerWidth && setSize(settings.innerWidth, 'x');
-		
+		trigger(event_load);
+		settings.get('onLoad');
+
+		settings.h = settings.get('height') ?
+		setSize(settings.get('height'), 'y') - loadedHeight - interfaceHeight :
+		settings.get('innerHeight') && setSize(settings.get('innerHeight'), 'y');
+
+		settings.w = settings.get('width') ?
+		setSize(settings.get('width'), 'x') - loadedWidth - interfaceWidth :
+		settings.get('innerWidth') && setSize(settings.get('innerWidth'), 'x');
+
 		// Sets the minimum dimensions for use in image scaling
 		settings.mw = settings.w;
 		settings.mh = settings.h;
-		
+
 		// Re-evaluate the minimum width and height based on maxWidth and maxHeight values.
 		// If the width or height exceed the maxWidth or maxHeight, use the maximum values instead.
-		if (settings.maxWidth) {
-			settings.mw = setSize(settings.maxWidth, 'x') - loadedWidth - interfaceWidth;
+		if (settings.get('maxWidth')) {
+			settings.mw = setSize(settings.get('maxWidth'), 'x') - loadedWidth - interfaceWidth;
 			settings.mw = settings.w && settings.w < settings.mw ? settings.w : settings.mw;
 		}
-		if (settings.maxHeight) {
-			settings.mh = setSize(settings.maxHeight, 'y') - loadedHeight - interfaceHeight;
+		if (settings.get('maxHeight')) {
+			settings.mh = setSize(settings.get('maxHeight'), 'y') - loadedHeight - interfaceHeight;
 			settings.mh = settings.h && settings.h < settings.mh ? settings.h : settings.mh;
 		}
-		
-		href = settings.href;
-		
+
+		href = settings.get('href');
+
 		loadingTimer = setTimeout(function () {
-			$loadingOverlay.show().appendTo($content);
+			$loadingOverlay.show();
 		}, 100);
-		
-		if (settings.inline) {
+
+		if (settings.get('inline')) {
+			var $target = $(href).eq(0);
 			// Inserts an empty placeholder where inline content is being pulled from.
-			// An event is bound to put inline content back when ColorBox closes or loads new content.
-			$tag(div).hide().insertBefore($(href)[0]).one(event_purge, function () {
-				$(this).replaceWith($loaded.children());
+			// An event is bound to put inline content back when Colorbox closes or loads new content.
+			$inline = $('<div>').hide().insertBefore($target);
+
+			$events.one(event_purge, function () {
+				$inline.replaceWith($target);
 			});
-			prep($(href));
-		} else if (settings.iframe) {
+
+			prep($target);
+		} else if (settings.get('iframe')) {
 			// IFrame element won't be added to the DOM until it is ready to be displayed,
 			// to avoid problems with DOM-ready JS that might be trying to run in that iframe.
 			prep(" ");
-		} else if (settings.html) {
-			prep(settings.html);
-		} else if (isImage(href)) {
-			$(photo = new Image())
-			.addClass(prefix + 'Photo')
-			.error(function () {
-				settings.title = false;
-				prep($tag(div, 'Error').html(settings.imgError));
-			})
-			.load(function () {
-				var percent;
-				photo.onload = null; //stops animated gifs from firing the onload repeatedly.
-				
-				if (settings.scalePhotos) {
-					setResize = function () {
-						photo.height -= photo.height * percent;
-						photo.width -= photo.width * percent;
-					};
-					if (settings.mw && photo.width > settings.mw) {
-						percent = (photo.width - settings.mw) / photo.width;
-						setResize();
+		} else if (settings.get('html')) {
+			prep(settings.get('html'));
+		} else if (isImage(settings, href)) {
+
+			href = retinaUrl(settings, href);
+
+			photo = settings.get('createImg');
+
+			$(photo)
+				.addClass(prefix + 'Photo')
+				.bind('error.'+prefix,function () {
+					prep($tag(div, 'Error').html(settings.get('imgError')));
+				})
+				.one('load', function () {
+					if (request !== requests) {
+						return;
 					}
-					if (settings.mh && photo.height > settings.mh) {
-						percent = (photo.height - settings.mh) / photo.height;
-						setResize();
-					}
-				}
-				
-				if (settings.h) {
-					photo.style.marginTop = Math.max(settings.h - photo.height, 0) / 2 + 'px';
-				}
-				
-				if ($related[1] && (settings.loop || $related[index + 1])) {
-					photo.style.cursor = 'pointer';
-					photo.onclick = function () {
-						publicMethod.next();
-					};
-				}
-				
-				if (isIE) {
-					photo.style.msInterpolationMode = 'bicubic';
-				}
-				
-				setTimeout(function () { // A pause because Chrome will sometimes report a 0 by 0 size otherwise.
-					prep(photo);
-				}, 1);
-			});
-			
-			setTimeout(function () { // A pause because Opera 10.6+ will sometimes not run the onload function otherwise.
-				photo.src = href;
-			}, 1);
+
+					// A small pause because some browsers will occassionaly report a
+					// img.width and img.height of zero immediately after the img.onload fires
+					setTimeout(function(){
+						var percent;
+
+						if (settings.get('retinaImage') && window.devicePixelRatio > 1) {
+							photo.height = photo.height / window.devicePixelRatio;
+							photo.width = photo.width / window.devicePixelRatio;
+						}
+
+						if (settings.get('scalePhotos')) {
+							setResize = function () {
+								photo.height -= photo.height * percent;
+								photo.width -= photo.width * percent;
+							};
+							if (settings.mw && photo.width > settings.mw) {
+								percent = (photo.width - settings.mw) / photo.width;
+								setResize();
+							}
+							if (settings.mh && photo.height > settings.mh) {
+								percent = (photo.height - settings.mh) / photo.height;
+								setResize();
+							}
+						}
+
+						if (settings.h) {
+							photo.style.marginTop = Math.max(settings.mh - photo.height, 0) / 2 + 'px';
+						}
+
+						if ($related[1] && (settings.get('loop') || $related[index + 1])) {
+							photo.style.cursor = 'pointer';
+
+							$(photo).bind('click.'+prefix, function () {
+								publicMethod.next();
+							});
+						}
+
+						photo.style.width = photo.width + 'px';
+						photo.style.height = photo.height + 'px';
+						prep(photo);
+					}, 1);
+				});
+
+			photo.src = href;
+
 		} else if (href) {
-			$loadingBay.load(href, settings.data, function (data, status) {
-				prep(status === 'error' ? $tag(div, 'Error').html(settings.xhrError) : $(this).contents());
+			$loadingBay.load(href, settings.get('data'), function (data, status) {
+				if (request === requests) {
+					prep(status === 'error' ? $tag(div, 'Error').html(settings.get('xhrError')) : $(this).contents());
+				}
 			});
 		}
-	};
-		
+	}
+
 	// Navigates to the next page/image in a set.
 	publicMethod.next = function () {
-		if (!active && $related[1] && (settings.loop || $related[index + 1])) {
+		if (!active && $related[1] && (settings.get('loop') || $related[index + 1])) {
 			index = getIndex(1);
-			publicMethod.load();
-		}
-	};
-	
-	publicMethod.prev = function () {
-		if (!active && $related[1] && (settings.loop || index)) {
-			index = getIndex(-1);
-			publicMethod.load();
+			launch($related[index]);
 		}
 	};
 
-	// Note: to use this within an iframe use the following format: parent.$.fn.colorbox.close();
+	publicMethod.prev = function () {
+		if (!active && $related[1] && (settings.get('loop') || index)) {
+			index = getIndex(-1);
+			launch($related[index]);
+		}
+	};
+
+	// Note: to use this within an iframe use the following format: parent.jQuery.colorbox.close();
 	publicMethod.close = function () {
 		if (open && !closing) {
-			
+
 			closing = true;
-			
 			open = false;
-			
-			trigger(event_cleanup, settings.onCleanup);
-			
-			$window.unbind('.' + prefix + ' .' + event_ie6);
-			
-			$overlay.fadeTo(200, 0);
-			
-			$box.stop().fadeTo(300, 0, function () {
-			
-				$box.add($overlay).css({'opacity': 1, cursor: 'auto'}).hide();
-				
+			trigger(event_cleanup);
+			settings.get('onCleanup');
+			$window.unbind('.' + prefix);
+			$overlay.fadeTo(settings.get('fadeOut') || 0, 0);
+
+			$box.stop().fadeTo(settings.get('fadeOut') || 0, 0, function () {
+				$box.hide();
+				$overlay.hide();
 				trigger(event_purge);
-				
 				$loaded.remove();
-				
+
 				setTimeout(function () {
 					closing = false;
-					trigger(event_closed, settings.onClosed);
+					trigger(event_closed);
+					settings.get('onClosed');
 				}, 1);
 			});
 		}
 	};
 
-	// Removes changes ColorBox made to the document, but does not remove the plugin
-	// from jQuery.
+	// Removes changes Colorbox made to the document, but does not remove the plugin.
 	publicMethod.remove = function () {
-		$([]).add($box).add($overlay).remove();
+		if (!$box) { return; }
+
+		$box.stop();
+		$[colorbox].close();
+		$box.stop(false, true).remove();
+		$overlay.remove();
+		closing = false;
 		$box = null;
 		$('.' + boxElement)
 			.removeData(colorbox)
 			.removeClass(boxElement);
 
-		$(document).undelegate('.'+boxElement);
+		$(document).unbind('click.'+prefix).unbind('keydown.'+prefix);
 	};
 
-	// A method for fetching the current element ColorBox is referencing.
+	// A method for fetching the current element Colorbox is referencing.
 	// returns a jQuery object.
 	publicMethod.element = function () {
-		return $(element);
+		return $(settings.el);
 	};
 
 	publicMethod.settings = defaults;


### PR DESCRIPTION
I wanted to fix an undefined method console log entry for the first run wizard. Fixing this revealed that the colorbox plugin uses not available private variable of jQuery and produces the next error. So I also upgraded the colorbox plugin.

Best viewed in "whitespace cleaned diff".

I tested it in Safari, Firefox, IE10, IE11, Edge, Opera and Chrome. All works and looks like before.

The crucial commit is 	29e7e53

cc @LukasReschke @nickvergessen @rullzer 