### PR TITLE
fix translation string to not contain tabs

### DIFF
--- a/templates/wizard.php
+++ b/templates/wizard.php
@@ -62,13 +62,7 @@
 
 <p class="footnote">
 <?php print_unescaped($l->t('There’s more information in the <a target="_blank" href="%s">documentation</a> and on our <a target="_blank" href="%s">website</a>.', array($theme->getDocBaseUrl(), $theme->getBaseUrl()))); ?><br>
-<?php print_unescaped($l->t('If you like Nextcloud,
-	<a href="mailto:?subject=Nextcloud
-		&body=Nextcloud is a great open software to sync and share your files.
-		You can freely get it from https://nextcloud.com">
-		recommend it to your friends</a>
-	and <a href="https://nextcloud.com/contribute/"
-		target="_blank">contribute back</a>!')); ?>
+<?php print_unescaped($l->t('If you like Nextcloud, <a href="mailto:?subject=Nextcloud &body=Nextcloud is a great open software to sync and share your files. You can freely get it from https://nextcloud.com"> recommend it to your friends</a> and <a href="https://nextcloud.com/contribute/" target="_blank">contribute back</a>!')); ?>
 </p>
 
 </div>


### PR DESCRIPTION
This caused translators to copy the visual representation of the tabs resulting in weird text:

<img width="739" alt="bildschirmfoto 2016-09-22 um 14 24 33" src="https://cloud.githubusercontent.com/assets/245432/18748001/9a061fb6-80d0-11e6-8fe9-34157707d449.png">

cc @nextcloud/designers @nickvergessen @schiessle @blizzz 