### PR TITLE
Fix settings route from /personal to /user

### DIFF
--- a/lib/Notification/Notifier.php
+++ b/lib/Notification/Notifier.php
@@ -79,7 +79,7 @@ class Notifier implements INotifier {
 				}
 
 				$notification->setParsedSubject($subject)
-					->setLink($this->url->getAbsoluteURL('index.php/settings/personal'));
+					->setLink($this->url->linkToRouteAbsolute('settings.PersonalSettings.index'));
 				return $notification;
 
 			default:

--- a/tests/Notification/NotifierTest.php
+++ b/tests/Notification/NotifierTest.php
@@ -176,7 +176,7 @@ class NotifierTest extends TestCase {
 				->with($notification);
 
 			$this->urlGenerator->expects($this->never())
-				->method('getAbsoluteURL');
+				->method('linkToRouteAbsolute');
 
 			$notification->expects($this->never())
 				->method('setParsedSubject');
@@ -194,9 +194,9 @@ class NotifierTest extends TestCase {
 				->willReturn($this->l);
 
 			$this->urlGenerator->expects($this->once())
-				->method('getAbsoluteURL')
-				->with('index.php/settings/personal')
-				->willReturnArgument(0);
+				->method('linkToRouteAbsolute')
+				->with('settings.PersonalSettings.index')
+				->willReturn('https://example.org/settings/user');
 
 			$notification->expects($this->once())
 				->method('setParsedSubject')
@@ -204,7 +204,7 @@ class NotifierTest extends TestCase {
 				->willReturnSelf();
 			$notification->expects($this->once())
 				->method('setLink')
-				->with($this->stringEndsWith('/settings/personal'))
+				->with($this->stringEndsWith('/settings/user'))
 				->willReturnSelf();
 		}
 


### PR DESCRIPTION
Since that was changed with the move to unified settings, already in Nextcloud 12. So we should backport this too. Please review @nickvergessen @blizzz 