### PR TITLE
Fix double escaping of slogan

### DIFF
--- a/templates/wizard.php
+++ b/templates/wizard.php
@@ -18,7 +18,7 @@
 	</p>
 </div>
 
-<h1><?php p($theme->getSlogan()); ?></h1>
+<h1><?php print_unescaped($theme->getSlogan()); ?></h1>
 <p><?php p($l->t('Access & share your files, calendars, contacts, mail & more from any device, on your terms'));?></p>
 
 </div>


### PR DESCRIPTION
Slogan is already escaped in https://github.com/nextcloud/server/blob/cce4c285dbfd6957f50112b234b3545ebcceac54/apps/theming/lib/ThemingDefaults.php#L142

Fixes nextcloud/server#7460
