### PR TITLE
Fixes for template texts

### DIFF
--- a/templates/page.apps.php
+++ b/templates/page.apps.php
@@ -35,8 +35,8 @@
 			<li><?php p($l->t('Groupware apps like Calendar, Contacts, Mail')); ?></li>
 			<li><?php p($l->t('Communication with Nextcloud Talk')); ?></li>
 			<li><?php p($l->t('Collaboration apps for document editing')); ?></li>
-			<li><?php p($l->t('Security and authentication features like two-factor authentication, SSO and randsomware protection')); ?></li>
-			<li><?php p($l->t('Many others like a music players, password managers, a kanban app, download manager or a markdown editor')); ?></li>
+			<li><?php p($l->t('Security and authentication features like two-factor authentication, SSO and ransomware protection')); ?></li>
+			<li><?php p($l->t('Many others like a music player, a password manager, a kanban app, a download manager or a markdown editor')); ?></li>
 
 		</ul>
 		<p class="details-link"><a href="/index.php/settings/apps" target="_blank"><?php p($l->t('Browse the app store')); ?></a></p>

--- a/templates/page.apps.php
+++ b/templates/page.apps.php
@@ -27,7 +27,7 @@
  * @var \OCP\Defaults $theme
  */
 ?>
-<div class="page" data-title="Extend your cloud" data-subtitle="">
+<div class="page" data-title="<?php p($l->t('Extend your cloud')); ?>" data-subtitle="">
 	<div class="image"><img src="<?php p(image_path('firstrunwizard', 'appstore.svg')); ?>" /></div>
 	<div class="description">
 		<p><?php p($l->t('Find more than 100 apps in the Nextcloud app store to customize your cloud:')); ?></p>

--- a/templates/page.final.php
+++ b/templates/page.final.php
@@ -31,7 +31,7 @@
 		</div>
 		<div class="description-block">
 			<h2 class="icon-world"><?php p($l->t('Enterprise support')); ?></h2>
-			<p><?php p($l->t('If you run Nextcloud in a mission critical environment with large numbers of users and big amounts of data and need the certainty of support from the experts behind the Nextcloud technology, a Enterprise Subscription from Nextcloud is available with email and phone support.')); ?></p>
+			<p><?php p($l->t('If you run Nextcloud in a mission critical environment with large numbers of users and big amounts of data and need the certainty of support from the experts behind the Nextcloud technology, an Enterprise Subscription from Nextcloud is available with email and phone support.')); ?></p>
 			<a href="https://nextcloud.com/enterprise/buy" class="button"><?php p($l->t('Get enterprise support')); ?></a>
 		</div>
 	</div>

--- a/templates/page.final.php
+++ b/templates/page.final.php
@@ -27,7 +27,7 @@
 		<div class="description-block">
 			<h2 class="icon-user"><?php p($l->t('Start contributing')); ?></h2>
 			<p><?php p($l->t('Do you want to get a certain improvement in Nextcloud? Did you find a problem? Do you want to help translate, promote or document Nextcloud?')); ?></p>
-			<a href="https://nextcloud.com/contribute/" class="button"><?php p($l->t('Become part of the Community.')); ?></a>
+			<a href="https://nextcloud.com/contribute/" class="button"><?php p($l->t('Become part of the Community')); ?></a>
 		</div>
 		<div class="description-block">
 			<h2 class="icon-world"><?php p($l->t('Enterprise support')); ?></h2>

--- a/templates/page.values.php
+++ b/templates/page.values.php
@@ -37,7 +37,7 @@
 		<ul id="wizard-values">
 			<li>
 				<span class="icon-world"></span>
-				<h2><?php p($l->t('Host you data and files where you decide')); ?></h2>
+				<h2><?php p($l->t('Host your data and files where you decide')); ?></h2>
 			</li>
 			<li>
 				<span class="icon-share"></span>

--- a/templates/page.values.php
+++ b/templates/page.values.php
@@ -28,7 +28,7 @@
  */
 ?>
 
-<div class="page" data-title="A safe home for all your data" data-subtitle="">
+<div class="page" data-title="<?php p($l->t('A safe home for all your data')); ?>" data-subtitle="">
 	<div class="content content-values">
 		<p>
 			<?php p($l->t('Nextcloud puts your data at your fingertips, under your control. Store your documents, calendar, contacts and photos on a server in your company, at home, at one of our providers or in a data center you know.')); ?>

--- a/templates/personal-settings.php
+++ b/templates/personal-settings.php
@@ -46,7 +46,7 @@ script('firstrunwizard', ['jquery.colorbox', 'firstrunwizard']);
 				 alt="<?php p($l->t('iOS app'));?>" />
 		</a>
 	</div>
-	<p><?php print_unescaped($l->t('Setup sync clients using an <a href="">app password</a>. That way you can make sure you are able to revoke access in case you loose that device.')); ?></p>
+	<p><?php print_unescaped($l->t('Setup sync clients using an <a href="">app password</a>. That way you can make sure you are able to revoke access in case you lose that device.')); ?></p>
 </div>
 <div class="followupsection">
 	<h2><?php p($l->t('Connect other apps to %s', array($theme->getName()))); ?></h2>


### PR DESCRIPTION
This pull request fixes some missing internationalization and typos in the texts of the templates.

Some things that I did not know how to fix:
- [Missing link href in _page-settings.php_](https://github.com/nextcloud/firstrunwizard/blob/0612c1f9382c88c480471518a55d2f88d7c88477/templates/personal-settings.php#L49) @juliushaertl 
- [Link to IRC chat channel](https://github.com/nextcloud/firstrunwizard/blob/cf4e7f92b33e33cc6f8e8953fd33c48e1107d260/templates/page.final.php#L22), maybe use `irc://#nextcloud@freenode.net` or `https://webchat.freenode.net/?channels=nextcloud` instead of the contribute page? @jancborchardt 
- Upper case or lower case for the first letter of items in a list? Most lists use upper case, although the [list of community support channels](https://github.com/nextcloud/firstrunwizard/blob/cf4e7f92b33e33cc6f8e8953fd33c48e1107d260/templates/page.final.php#L21-L22) use lower case, but I don't know which would be the proper one in English.
- In some places Nextcloud is mentioned, while in other places the name returned by the theme is used. Also, I am not sure if the _First run wizard_, with its current content that talks about what you can do on the instance but also how to contribute to the main project, would make sense in a themed instance. @nextcloud/theming 

Oh, and I also miss _Free Software_ mentioned in the values :-P (But yes, nowadays _Open Source_ is a more popular term, even if it does not mean the same :'( ).
