### PR TITLE
Fix link to Nextcloud IRC chat channel

### DIFF
--- a/templates/page.final.php
+++ b/templates/page.final.php
@@ -19,7 +19,7 @@
 			<p><?php p($l->t('You can also ask for help in our community support channels:')); ?></p>
 			<ul>
 				<li><a href="https://help.nextcloud.com"><?php p($l->t('the Nextcloud forums')); ?></a></li>
-				<li><a href="https://nextcloud.com/contribute/"><?php p($l->t('the Nextcloud IRC chat channel on freenode.net')); ?></a></li>
+				<li><a href="https://riot.im/app/#/room/#freenode_#nextcloud:matrix.org"><?php p($l->t('the Nextcloud IRC chat channel on freenode.net')); ?></a></li>
 			</ul>
 		</div>
 	</div>


### PR DESCRIPTION
[Riot was used as requested by @jancborchardt](https://github.com/nextcloud/firstrunwizard/pull/68#issuecomment-394449060).