### PR TITLE
Design detail and accessibility fixes

### DIFF
--- a/css/firstrunwizard.scss
+++ b/css/firstrunwizard.scss
@@ -1,7 +1,7 @@
 @import 'colorbox.scss';
 
 #cboxLoadedContent {
-	border-radius: 3px;
+	border-radius: var(--border-radius-large);
 	overflow: hidden !important;
 }
 

--- a/css/firstrunwizard.scss
+++ b/css/firstrunwizard.scss
@@ -25,14 +25,15 @@
 	margin: 0 auto;
 }
 
-#firstrunwizard h1 {
+#firstrunwizard h2 {
 	font-size: 40px;
+	color: var(--color-primary-text);
 	font-weight: 300;
 	line-height: 120%;
-	padding: 0 0 10px
+	padding: 0 0 10px;
 }
 
-#firstrunwizard h2 {
+#firstrunwizard h3 {
 	margin: 30px 0 10px;
 	line-height: 120%;
 	padding: 0;
@@ -57,7 +58,7 @@
 	display: flex;
 	flex-direction: row;
 	flex-wrap: wrap;
-	h2 {
+	h3 {
 		margin: 0 0 10px 0;
 	}
 	.image {
@@ -134,7 +135,7 @@
 		}
 	}
 	.content-final {
-		h2 {
+		h3 {
 			background-position: 0;
 			background-size: 16px 16px;
 			padding-left: 26px;
@@ -216,7 +217,7 @@
 			background-size: 40px;
 			margin: auto;
 		}
-		h2 {
+		h3 {
 			margin: 10px 0 10px 0;
 			font-size: 130%;
 			text-align: center;
@@ -240,7 +241,7 @@
 		.firstrunwizard-header div.logo {
 			background-size: 120px;
 		}
-		h1 {
+		h2 {
 			font-size: 20px;
 		}
 		.page > div {
@@ -255,7 +256,7 @@
 				min-width: 50px;
 				padding-right: 20px;
 			}
-			span, h2 {
+			span, h3 {
 				font-size: 12px;
 				text-align: left;
 			}

--- a/css/firstrunwizard.scss
+++ b/css/firstrunwizard.scss
@@ -95,7 +95,10 @@
 		}
 	}
 	a:not(.button) {
-		text-decoration: underline;
+		&:hover,
+		&:focus {
+			text-decoration: underline;
+		}
 	}
 	.button {
 		display: inline-block;

--- a/templates/page.clients.php
+++ b/templates/page.clients.php
@@ -33,7 +33,7 @@
 		<p><?php p($l->t('Nextcloud gives you access to your files wherever you are.')); ?><br />
 			<?php p($l->t('Our easy to use desktop and mobile clients are available for all major platforms at zero cost!')); ?></p>
 		<div class="description-block">
-			<h2><?php p($l->t('Get the apps to sync your files')); ?></h2>
+			<h3><?php p($l->t('Get the apps to sync your files')); ?></h3>
 			<a target="_blank" href="<?php p($_['desktop']); ?>">
 				<img src="<?php p(image_path('core', 'desktopapp.svg')); ?>"
 					 alt="<?php p($l->t('Desktop client')); ?>"/>
@@ -49,7 +49,7 @@
 			</a>
 		</div>
 		<div class="description-block">
-			<h2><?php p($l->t('Connect your desktop apps to %s', array($theme->getName()))); ?></h2>
+			<h3><?php p($l->t('Connect your desktop apps to %s', array($theme->getName()))); ?></h3>
 			<a target="_blank" class="button"
 			   href="<?php p(link_to_docs('user-sync-calendars')) ?>">
 				<span class="icon icon-calendar-dark"></span>

--- a/templates/page.final.php
+++ b/templates/page.final.php
@@ -9,7 +9,7 @@
 <div class="page content-final" data-title="<?php p($l->t('Get help')); ?>" data-subtitle="">
 	<div class="description">
 		<div class="description-block">
-			<h2 class="icon-info"><?php p($l->t('Get more information')); ?></h2>
+			<h3 class="icon-info"><?php p($l->t('Get more information')); ?></h3>
 			<p><?php p($l->t('The Nextcloud documentation for home users:')); ?></p>
 			<ul>
 				<li><a href="<?php p(link_to_docs('user-')) ?>"><?php p($l->t('User manual')); ?></a></li>
@@ -25,12 +25,12 @@
 	</div>
 	<div class="description">
 		<div class="description-block">
-			<h2 class="icon-user"><?php p($l->t('Start contributing')); ?></h2>
+			<h3 class="icon-user"><?php p($l->t('Start contributing')); ?></h3>
 			<p><?php p($l->t('Do you want to get a certain improvement in Nextcloud? Did you find a problem? Do you want to help translate, promote or document Nextcloud?')); ?></p>
 			<a href="https://nextcloud.com/contribute/" class="button"><?php p($l->t('Become part of the Community')); ?></a>
 		</div>
 		<div class="description-block">
-			<h2 class="icon-world"><?php p($l->t('Enterprise support')); ?></h2>
+			<h3 class="icon-world"><?php p($l->t('Enterprise support')); ?></h3>
 			<p><?php p($l->t('If you run Nextcloud in a mission critical environment with large numbers of users and big amounts of data and need the certainty of support from the experts behind the Nextcloud technology, an Enterprise Subscription from Nextcloud is available with email and phone support.')); ?></p>
 			<a href="https://nextcloud.com/enterprise/buy" class="button"><?php p($l->t('Get enterprise support')); ?></a>
 		</div>

--- a/templates/page.values.php
+++ b/templates/page.values.php
@@ -37,15 +37,15 @@
 		<ul id="wizard-values">
 			<li>
 				<span class="icon-world"></span>
-				<h2><?php p($l->t('Host your data and files where you decide')); ?></h2>
+				<h3><?php p($l->t('Host your data and files where you decide')); ?></h3>
 			</li>
 			<li>
 				<span class="icon-shared"></span>
-				<h2><?php p($l->t('Open Standards and Interoperability')); ?></h2>
+				<h3><?php p($l->t('Open Standards and Interoperability')); ?></h3>
 			</li>
 			<li>
 				<span class="icon-user"></span>
-				<h2><?php p($l->t('100%% Open Source & community-focused')); ?></h2>
+				<h3><?php p($l->t('100%% Open Source & community-focused')); ?></h3>
 			</li>
 		</ul>
 

--- a/templates/wizard.php
+++ b/templates/wizard.php
@@ -19,7 +19,7 @@
 			</p>
 		</div>
 
-		<h1><?php p($theme->getSlogan()); ?></h1>
+		<h2><?php p($theme->getSlogan()); ?></h2>
 		<p></p>
 
 	</div>


### PR DESCRIPTION
- Bump down headings one level for proper structure, as @pixelipo suggested in https://github.com/nextcloud/server/pull/11993#issuecomment-433352533 – still looks the same as I took over the styles too
- Use standardized border-radius
- Only underline links on hover/focus for keyboard accessibility 

![first run wizard design details](https://user-images.githubusercontent.com/925062/47780761-51614a80-dcfc-11e8-8e55-05a03f37197c.gif)


Please review @juliushaertl @pixelipo @nextcloud/designers :)