### PR TITLE
Hide appstore when disabled

### DIFF
--- a/lib/Controller/WizardController.php
+++ b/lib/Controller/WizardController.php
@@ -29,7 +29,7 @@ use OCP\Defaults;
 use OCP\IConfig;
 use OCP\IRequest;
 
-class WizardController extends Controller  {
+class WizardController extends Controller {
 
 	/** @var IConfig */
 	protected $config;
@@ -37,17 +37,22 @@ class WizardController extends Controller  {
 	/** @var string */
 	protected $userId;
 
+	/** @var Defaults */
+	protected $theming;
+
 	/**
 	 * @param string $appName
 	 * @param IRequest $request
 	 * @param IConfig $config
 	 * @param string $userId
+	 * @param Defaults $theming
 	 */
-	public function __construct($appName, IRequest $request, IConfig $config, $userId) {
+	public function __construct($appName, IRequest $request, IConfig $config, $userId, Defaults $theming) {
 		parent::__construct($appName, $request);
 
 		$this->config = $config;
 		$this->userId = $userId;
+		$this->theming = $theming;
 	}
 
 	/**
@@ -64,12 +69,11 @@ class WizardController extends Controller  {
 	 * @return TemplateResponse
 	 */
 	public function show() {
-		/** @var Defaults $theming */
-		$theming = \OC::$server->query(Defaults::class);
 		return new TemplateResponse('firstrunwizard', 'wizard', [
-			'desktop'      => $this->config->getSystemValue('customclient_desktop', $theming->getSyncClientUrl()),
-			'android'      => $this->config->getSystemValue('customclient_android', $theming->getAndroidClientUrl()),
-			'ios'          => $this->config->getSystemValue('customclient_ios', $theming->getiOSClientUrl()),
+			'desktop' => $this->config->getSystemValue('customclient_desktop', $this->theming->getSyncClientUrl()),
+			'android' => $this->config->getSystemValue('customclient_android', $this->theming->getAndroidClientUrl()),
+			'ios' => $this->config->getSystemValue('customclient_ios', $this->theming->getiOSClientUrl()),
+			'appStore' => $this->config->getSystemValue('appstoreenabled', true),
 		], '');
 	}
 }

--- a/templates/wizard.php
+++ b/templates/wizard.php
@@ -31,7 +31,7 @@
 		print_unescaped($this->inc('page.clients'));
 
 		$uid = \OC::$server->getUserSession()->getUser()->getUID();
-		if (OC_User::isAdminUser($uid)) {
+		if ($_['appStore'] && OC_User::isAdminUser($uid)) {
 			print_unescaped($this->inc('page.apps'));
 		}
 		print_unescaped($this->inc('page.final'));

--- a/tests/Controller/WizardControllerTest.php
+++ b/tests/Controller/WizardControllerTest.php
@@ -27,6 +27,7 @@ namespace OCA\FirstRunWizard\Tests\Controller;
 use OCA\FirstRunWizard\Controller\WizardController;
 use OCP\AppFramework\Http;
 use OCP\AppFramework\Http\DataResponse;
+use OCP\Defaults;
 use OCP\IConfig;
 use OCP\IRequest;
 use Test\TestCase;
@@ -55,7 +56,8 @@ class WizardControllerTest extends TestCase {
 			'firstrunwizard',
 			$this->createMock(IRequest::class),
 			$this->config,
-			$user
+			$user,
+			\OC::$server->query(Defaults::class)
 		);
 	}
 
@@ -85,8 +87,8 @@ class WizardControllerTest extends TestCase {
 
 	public function dataShow() {
 		return [
-			['desktop1', 'android1', 'ios1'],
-			['desktop2', 'android2', 'ios2'],
+			['desktop1', 'android1', 'ios1', true],
+			['desktop2', 'android2', 'ios2', false],
 		];
 	}
 
@@ -95,16 +97,18 @@ class WizardControllerTest extends TestCase {
 	 * @param string $desktopUrl
 	 * @param string $androidUrl
 	 * @param string $iosUrl
+	 * @param bool $appStoreEnabled
 	 */
-	public function testShow($desktopUrl, $androidUrl, $iosUrl) {
+	public function testShow($desktopUrl, $androidUrl, $iosUrl, $appStoreEnabled) {
 		$controller = $this->getController();
 
-		$this->config->expects($this->exactly(3))
+		$this->config->expects($this->exactly(4))
 			->method('getSystemValue')
 			->willReturnMap([
 				['customclient_desktop', 'https://nextcloud.com/install/#install-clients', $desktopUrl],
 				['customclient_android', 'https://play.google.com/store/apps/details?id=com.nextcloud.client', $androidUrl],
 				['customclient_ios', 'https://geo.itunes.apple.com/us/app/nextcloud/id1125420102?mt=8', $iosUrl],
+				['appstoreenabled', true, $appStoreEnabled]
 			]);
 
 		$response = $controller->show();
@@ -115,6 +119,7 @@ class WizardControllerTest extends TestCase {
 			'desktop' => $desktopUrl,
 			'android' => $androidUrl,
 			'ios' => $iosUrl,
+			'appStore' => $appStoreEnabled,
 		], $response->getParams());
 	}
 }


### PR DESCRIPTION
Closes https://github.com/nextcloud/server/issues/13061

If `appstoreenabled = false` slide for appstore is not displayed.

cc @jernst