### PR TITLE
Avoid double encoding in slogan

### DIFF
--- a/templates/wizard.php
+++ b/templates/wizard.php
@@ -19,7 +19,7 @@
 			</p>
 		</div>
 
-		<h2><?php p($theme->getSlogan()); ?></h2>
+		<h2><?php print_unescaped(htmlspecialchars($theme->getSlogan(), ENT_QUOTES, 'UTF-8', false)); ?></h2>
 		<p></p>
 
 	</div>


### PR DESCRIPTION
This makes sure we don't double encode the slogan, in cases where it is already sanitized with `\OCP\Util::sanitizeHTML()`

Fixes #67 