### PR TITLE
Fix first run wizard for dark theme

### DIFF
--- a/css/firstrunwizard.scss
+++ b/css/firstrunwizard.scss
@@ -1,6 +1,7 @@
 @import 'colorbox.scss';
 
 #cboxLoadedContent {
+	background-color: var(--color-main-background) !important;
 	border-radius: var(--border-radius-large);
 	overflow: hidden !important;
 }
@@ -39,13 +40,6 @@
 	padding: 0;
 }
 
-.clientslinks .appsmall {
-	height: 32px;
-	width: 32px;
-	position: relative;
-	opacity: .5;
-	vertical-align: middle;
-}
 .clientslinks .button {
 	display: inline-block;
 	padding: 8px;
@@ -232,11 +226,8 @@
 	text-align: center;
 }
 
-.icon-source {
-	background-image: url('../img/source.svg');
-}
 .icon-world {
-	background-image: url('../img/world.svg');
+	background-image: var(--icon-link-000);
 }
 
 @media only screen and (max-width: 680px) {

--- a/templates/page.clients.php
+++ b/templates/page.clients.php
@@ -52,17 +52,17 @@
 			<h3><?php p($l->t('Connect your desktop apps to %s', array($theme->getName()))); ?></h3>
 			<a target="_blank" class="button"
 			   href="<?php p(link_to_docs('user-sync-calendars')) ?>" rel="noreferrer noopener">
-				<span class="icon icon-calendar-dark"></span>
+				<span class="icon-calendar-dark"></span>
 				<?php p($l->t('Connect your calendar')); ?>
 			</a>
 			<a target="_blank" class="button"
 			   href="<?php p(link_to_docs('user-sync-contacts')) ?>" rel="noreferrer noopener">
-				<span class="icon icon-contacts-dark"></span>
+				<span class="icon-contacts-dark"></span>
 				<?php p($l->t('Connect your contacts')); ?>
 			</a>
 			<a target="_blank" class="button"
 			   href="<?php p(link_to_docs('user-webdav')); ?>" rel="noreferrer noopener">
-				<span class="icon icon-files-dark"></span>
+				<span class="icon-files-dark"></span>
 				<?php p($l->t('Access files via WebDAV')); ?>
 			</a>
 		</div>

--- a/templates/personal-settings.php
+++ b/templates/personal-settings.php
@@ -58,18 +58,15 @@ script('firstrunwizard', ['jquery.colorbox', 'firstrunwizard']);
 
 	<div class="clientslinks">
 		<a target="_blank" class="button" href="<?php p(link_to_docs('user-sync-calendars')) ?>" rel="noreferrer noopener">
-			<img class="appsmall appsmall-calendar svg" alt=""
-				 src="<?php p(image_path('core', 'places/calendar.svg')); ?>" />
+			<span class="icon-calendar-dark"></span>
 			<?php p($l->t('Connect your calendar'));?>
 		</a>
 		<a target="_blank" class="button" href="<?php p(link_to_docs('user-sync-contacts')) ?>" rel="noreferrer noopener">
-			<img class="appsmall appsmall-contacts svg" alt=""
-				 src="<?php p(image_path('core', 'places/contacts.svg')); ?>" />
+			<span class="icon-contacts-dark"></span>
 			<?php p($l->t('Connect your contacts'));?>
 		</a>
 		<a target="_blank" class="button" href="<?php p(link_to_docs('user-webdav')); ?>" rel="noreferrer noopener">
-			<img class="appsmall svg" alt=""
-				 src="<?php p(image_path('files', 'folder.svg')); ?>" />
+			<span class="icon-files-dark"></span>
 			<?php p($l->t('Access files via WebDAV'));?>
 		</a>
 	</div>


### PR DESCRIPTION
Current dialog:
![firstrunwizard dark theme current](https://user-images.githubusercontent.com/925062/51314109-7a69bf80-1a4f-11e9-9fa1-0bb283c5b706.png)
Current settings:
![firstrunwizard settings fix](https://user-images.githubusercontent.com/925062/51314112-7b025600-1a4f-11e9-92d8-60998bc60e0e.png)


-----------------

Fixed now:
![firstrunwizard dark fixed](https://user-images.githubusercontent.com/925062/51314110-7b025600-1a4f-11e9-8fdc-e49d003c14fe.png)
![firstrunwizard dark theme fixes](https://user-images.githubusercontent.com/925062/51314111-7b025600-1a4f-11e9-9226-cc37c818a46e.png)


Please review @nextcloud/designers 

@juliushaertl as said in #106 I forgot about that Vue pull request. Still opening this, hope it’s useful? (As currently I can not compile the other pull request.)