### PR TITLE
Only add event listener if selector can be found

### DIFF
--- a/js/about.js
+++ b/js/about.js
@@ -1,13 +1,16 @@
 document.addEventListener('DOMContentLoaded', function() {
-	document.querySelector('#expanddiv li[data-id="firstrunwizard-about"] a').addEventListener('click', function (event) {
-		event.stopPropagation();
-		event.preventDefault();
-		OCP.Loader.loadScript('firstrunwizard', 'firstrunwizard.js').then(function() {
-			OCA.FirstRunWizard.open();
-			OC.hideMenus(function () {
-				return false;
+	var aboutEntry = document.querySelector('#expanddiv li[data-id="firstrunwizard-about"] a');
+	if (aboutEntry) {
+		aboutEntry.addEventListener('click', function (event) {
+			event.stopPropagation();
+			event.preventDefault();
+			OCP.Loader.loadScript('firstrunwizard', 'firstrunwizard.js').then(function () {
+				OCA.FirstRunWizard.open();
+				OC.hideMenus(function () {
+					return false;
+				});
 			});
+			return true;
 		});
-		return true;
-	});
+	}
 });


### PR DESCRIPTION
This fixes a console error on the login page, since the menu entry in the query selector is not present there.