### PR TITLE
Autoapprove dependabot

### DIFF
--- a/.github/workflows/dependabot-approve.yml
+++ b/.github/workflows/dependabot-approve.yml
@@ -1,0 +1,11 @@
+name: Dependabot auto approve
+on: pull_request
+
+jobs:
+  build:
+    runs-on: ubuntu-latest
+    steps:
+      - uses: hmarr/auto-approve-action@v2.0.0
+        if: github.actor == 'dependabot[bot]' || github.actor == 'dependabot-preview[bot]'
+        with:
+          github-token: "${{ secrets.GITHUB_TOKEN }}"


### PR DESCRIPTION
Just so things that can get merged and pass CI (dev deps for example) are automatically done.