### PR TITLE
Add fallback text for video on first slide to fix accessibility

### DIFF
--- a/src/components/IntroVideo.vue
+++ b/src/components/IntroVideo.vue
@@ -28,6 +28,7 @@
 			muted>
 			<source :src="videoWebm" type="video/webm">
 			<source :src="videoMp4" type="video/mp4">
+			{{ t('firstrunwizard', 'Welcome to Nextcloud!') }}
 		</video>
 	</div>
 </template>


### PR DESCRIPTION
Otherwise screen readers don’t read out anything here. Found thanks to feedback from @MarcoZehe! :)

I used the same method as in App.vue here. If we should use a branded name variable instead of the text "Nextcloud" here, a Vue expert needs to take over.