### PR TITLE
Extend reasons for email address

### DIFF
--- a/tests/Notification/NotifierTest.php
+++ b/tests/Notification/NotifierTest.php
@@ -25,6 +25,7 @@ namespace OCA\FirstRunWizard\Tests\Notification;
 
 use InvalidArgumentException;
 use OCA\FirstRunWizard\Notification\Notifier;
+use OCP\IConfig;
 use OCP\IImage;
 use OCP\IL10N;
 use OCP\IURLGenerator;
@@ -56,6 +57,7 @@ class NotifierTest extends TestCase {
 		$this->manager = $this->createMock(IManager::class);
 		$this->userManager = $this->createMock(IUserManager::class);
 		$this->urlGenerator = $this->createMock(IURLGenerator::class);
+		$this->config = $this->createMock(IConfig::class);
 		$this->l = $this->createMock(IL10N::class);
 		$this->l->expects($this->any())
 			->method('t')
@@ -71,7 +73,8 @@ class NotifierTest extends TestCase {
 			$this->factory,
 			$this->userManager,
 			$this->manager,
-			$this->urlGenerator
+			$this->urlGenerator,
+			$this->config
 		);
 	}
 


### PR DESCRIPTION
It's a bit confusing to be asked to enter an email address to be able to reset a password while the backend does not allow this at all (LDAP, SAML, ....)