### PR TITLE
Fix settings navigation order

### DIFF
--- a/appinfo/info.xml
+++ b/appinfo/info.xml
@@ -40,7 +40,7 @@ The First run wizard can be customized to meet specific design goals, or to chan
 			<name>About</name>
 			<route>files.view.index</route>
 			<icon>info.svg</icon>
-			<order>5</order>
+			<order>6</order>
 			<type>settings</type>
 		</navigation>
 	</navigations>


### PR DESCRIPTION
It has been bothering me for months :see_no_evil: 

| Before | After |
|:---------:|:------:|
|![dev skjnldsv com_apps_files__dir=_ fileid=108212](https://user-images.githubusercontent.com/14975046/162567674-0818e0a7-51a8-424c-9773-694e4f8090a9.png)|![dev skjnldsv com_apps_files_ (1)](https://user-images.githubusercontent.com/14975046/162567678-5cac31ec-e0bf-4f7e-b218-375f2063e96b.png)|