### PR TITLE
remove freenode chat from final page of frw

### DIFF
--- a/templates/page.final.php
+++ b/templates/page.final.php
@@ -31,7 +31,6 @@
 			<p><?php p($l->t('You can also ask for help in our community support channels:')); ?></p>
 			<ul>
 				<li><a href="https://help.nextcloud.com" target="_blank" rel="noreferrer noopener"><?php p($l->t('the Nextcloud forums')); ?></a></li>
-				<li><a href="https://riot.im/app/#/room/#freenode_#nextcloud:matrix.org" target="_blank" rel="noreferrer noopener"><?php p($l->t('the Nextcloud IRC chat channel on freenode.net')); ?></a></li>
 			</ul>
 		</div>
 	</div>


### PR DESCRIPTION
We do not use our freenode channels anymore. Upon discusion w/ Jos deleted.

Signed-off-by: Fabrice Mous <43647119+fabricemous@users.noreply.github.com>