### PR TITLE
Set native tooltip and notification on "copy link" button. Remove cus…

### DIFF
--- a/js/personalsettings.js
+++ b/js/personalsettings.js
@@ -7,40 +7,13 @@
 	})
 
 	function initLinkToClipboard() {
-		var originalTitle = t('firstrunwizard', 'Copy to clipboard')
-
-		/* reused from settings/js/authtoken_view.js */
-		$('#endpoint-url + .clipboardButton').tooltip({
-			placement: 'bottom',
-			title: originalTitle,
-			trigger: 'hover'
-		})
-
 		// Clipboard!
 		var clipboard = new Clipboard('.clipboardButton')
 		clipboard.on('success', function(e) {
-			var $input = $(e.trigger)
-
-			// show copied notification
-			$input.tooltip('hide')
-				.attr('data-original-title', t('firstrunwizard', 'Copied!'))
-				.tooltip('fixTitle')
-				.tooltip({
-					placement: 'bottom',
-					trigger: 'manual'
-				})
-				.tooltip('show')
-
-			// revert back to original title
-			_.delay(function() {
-				$input.tooltip('hide')
-					.attr('data-original-title', originalTitle)
-					.tooltip('fixTitle')
-			}, 3000)
+			OC.Notification.show(t('firstrunwizard', 'Copied!'), { type: 'success' })
 		})
 
 		clipboard.on('error', function(e) {
-			var $input = $(e.trigger)
 			var actionMsg = ''
 			if (/iPhone|iPad/i.test(navigator.userAgent)) {
 				actionMsg = t('firstrunwizard', 'Not supported!')
@@ -49,23 +22,8 @@
 			} else {
 				actionMsg = t('firstrunwizard', 'Press Ctrl-C to copy.')
 			}
-
 			// show error
-			$input.tooltip('hide')
-				.attr('data-original-title', actionMsg)
-				.tooltip('fixTitle')
-				.tooltip({
-					placement: 'bottom',
-					trigger: 'manual'
-				})
-				.tooltip('show')
-
-			// revert back to original title
-			_.delay(function() {
-				$input.tooltip('hide')
-					.attr('data-original-title', originalTitle)
-					.tooltip('fixTitle')
-			}, 3000)
+			OC.Notification.show(actionMsg, { type: 'error' })
 		})
 	}
 })(jQuery, OC, _)


### PR DESCRIPTION
Set native tooltip and notification on "copy link" button. Remove custom tooltip.

Resolves https://github.com/nextcloud/firstrunwizard/issues/804 
 
### Before:
![custom tooltip](https://user-images.githubusercontent.com/6078378/213741922-57ce7edc-ef4e-4918-87e2-7bb1a87b766e.gif)

### After:
![Screenshot from 2023-01-20 16-34-41](https://user-images.githubusercontent.com/6078378/213741974-f7ee875b-85b5-42b5-a285-996923e30c5e.png)


