### PR TITLE
feat(app-hints): Avoid sending app hints if the appstore is disabled

### DIFF
--- a/lib/Listener/BeforeTemplateRenderedListener.php
+++ b/lib/Listener/BeforeTemplateRenderedListener.php
@@ -82,7 +82,10 @@ class BeforeTemplateRenderedListener implements IEventListener {
 
 			$this->jobList->add('OCA\FirstRunWizard\Notification\BackgroundJob', ['uid' => $this->userSession->getUser()->getUID()]);
 		}
-		$this->appHint->sendAppHintNotifications();
+
+		if ($this->config->getSystemValueBool('appstoreenabled', true)) {
+			$this->appHint->sendAppHintNotifications();
+		}
 
 		Util::addScript(Application::APP_ID, 'about');
 	}


### PR DESCRIPTION
This will prevent app hints to be sent if the appstore is currently disabled. It will send them if the setting has been changed.