### PR TITLE
fix deprecated warning

### DIFF
--- a/lib/Settings/Personal.php
+++ b/lib/Settings/Personal.php
@@ -32,6 +32,8 @@ class Personal implements ISettings {
 
 	/** @var IConfig */
 	private $config;
+	/** @var IURLGenerator */
+	private $urlGenerator;
 	/** @var \OC_Defaults */
 	private $defaults;
 


### PR DESCRIPTION
I was getting this warning when in Debug mode.
```
Creation of dynamic property OCA\FirstRunWizard\Settings\Personal::$urlGenerator is deprecated at /mnt/HDExtra/nextcloud-server/nextcloud/apps/firstrunwizard/lib/Settings/Personal.php#40 
```