### PR TITLE
fix: Only show the wizard when any slides are configured (this is the default)

### DIFF
--- a/lib/Controller/WizardController.php
+++ b/lib/Controller/WizardController.php
@@ -21,10 +21,10 @@
 
 namespace OCA\FirstRunWizard\Controller;
 
-use OCA\FirstRunWizard\AppInfo\Application;
 use OCP\AppFramework\Controller;
 use OCP\AppFramework\Http\DataResponse;
 use OCP\AppFramework\Http\JSONResponse;
+use OCP\AppFramework\Services\IAppConfig;
 use OCP\Defaults;
 use OCP\IConfig;
 use OCP\IGroupManager;
@@ -32,37 +32,24 @@ use OCP\IRequest;
 
 class WizardController extends Controller {
 
-	/** @var IConfig */
-	protected $config;
-
-	/** @var string */
-	protected $userId;
-
-	/** @var Defaults */
-	protected $theming;
-
-	/** @var IGroupManager */
-	protected $groupManager;
-
-	/** @var array|false|string[] */
-	protected $slides = [];
-
 	/**
-	 * @param string $appName
-	 * @param IRequest $request
-	 * @param IConfig $config
-	 * @param string $userId
-	 * @param Defaults $theming
+	 * Array of enabled slides - allows an administrator to adjust what is shown
+	 * @var string[]
 	 */
-	public function __construct($appName, IRequest $request, IConfig $config, $userId, Defaults $theming, IGroupManager $groupManager) {
+	protected array $slides;
+
+	public function __construct(
+		string $appName,
+		IRequest $request,
+		protected string $userId,
+		protected IConfig $config,
+		protected IAppConfig $appConfig,
+		protected Defaults $theming,
+		protected IGroupManager $groupManager,
+	) {
 		parent::__construct($appName, $request);
 
-		$this->config = $config;
-		$this->userId = $userId;
-		$this->theming = $theming;
-		$this->groupManager = $groupManager;
-
-		$this->slides = explode(',', $this->config->getAppValue(Application::APP_ID, 'slides', 'video,values,apps,clients,final'));
+		$this->slides = $this->appConfig->getAppValueArray('slides', ['video', 'values', 'apps' ,'clients', 'final']);
 	}
 
 	/**

--- a/tests/Controller/WizardControllerTest.php
+++ b/tests/Controller/WizardControllerTest.php
@@ -27,10 +27,12 @@ use OCA\FirstRunWizard\AppInfo\Application;
 use OCA\FirstRunWizard\Controller\WizardController;
 use OCP\AppFramework\Http;
 use OCP\AppFramework\Http\DataResponse;
+use OCP\AppFramework\Services\IAppConfig;
 use OCP\Defaults;
 use OCP\IConfig;
 use OCP\IGroupManager;
 use OCP\IRequest;
+use PHPUnit\Framework\MockObject\MockObject;
 use Test\TestCase;
 
 /**
@@ -40,13 +42,14 @@ use Test\TestCase;
  * @group DB
  */
 class WizardControllerTest extends TestCase {
-	/** @var IConfig|\PHPUnit_Framework_MockObject_MockObject */
-	protected $config;
+	private IConfig|MockObject $config;
+	private IAppConfig|MockObject $appConfig;
 	private $groupManager;
 
 	protected function setUp(): void {
 		parent::setUp();
 		$this->config = $this->createMock(IConfig::class);
+		$this->appConfig = $this->createMock(IAppConfig::class);
 		$this->groupManager = $this->createMock(IGroupManager::class);
 	}
 
@@ -58,8 +61,9 @@ class WizardControllerTest extends TestCase {
 		return new WizardController(
 			'firstrunwizard',
 			$this->createMock(IRequest::class),
-			$this->config,
 			$user,
+			$this->config,
+			$this->appConfig,
 			\OC::$server->query(Defaults::class),
 			$this->groupManager
 		);


### PR DESCRIPTION
* Resolves: #708 

Only show the wizard and the "about" menu  entry if any slides are configured to be shown.

This also fixes deprecation warning when using `IConfig::getAppValue` by switching to `IAppConfig`.