### PR TITLE
fix: Remove legacy code that caused errors

### DIFF
--- a/appinfo/routes.php
+++ b/appinfo/routes.php
@@ -21,7 +21,6 @@
 
 return [
 	'routes' => [
-		['name' => 'Wizard#show', 'url' => '/wizard', 'verb' => 'GET'],
 		['name' => 'Wizard#disable', 'url' => '/wizard', 'verb' => 'DELETE'],
 	],
 ];

--- a/templates/personal-settings.php
+++ b/templates/personal-settings.php
@@ -58,7 +58,7 @@ $usesTLS = \OC::$server->getRequest()->getServerProtocol() === 'https';
 		<p><?php print_unescaped($l->t('Set up sync clients using an <a href="%s">app password</a>. That way you can make sure you are able to revoke access in case you lose that device.', [$appPasswordUrl])); ?></p>
 	</div>
 	<div class="section">
-		<h2><?php p($l->t('Connect other apps to %s', array($theme->getName()))); ?></h2>
+		<h2><?php p($l->t('Connect other apps to %s', [$theme->getName()])); ?></h2>
 
 		<p class="settings-hint"><?php print_unescaped($l->t('Besides the mobile apps and desktop client you can connect any other software that supports the WebDAV/CalDAV/CardDAV protocols to %s.', [$theme->getName()])); ?></p>
 

--- a/tests/AppInfo/ApplicationTest.php
+++ b/tests/AppInfo/ApplicationTest.php
@@ -1,24 +1,7 @@
 <?php
 /**
- * @copyright Copyright (c) 2016, Joas Schilling <coding@schilljs.com>
- *
- * @author Joas Schilling <coding@schilljs.com>
- *
- * @license GNU AGPL version 3 or any later version
- *
- * This program is free software: you can redistribute it and/or modify
- * it under the terms of the GNU Affero General Public License as
- * published by the Free Software Foundation, either version 3 of the
- * License, or (at your option) any later version.
- *
- * This program is distributed in the hope that it will be useful,
- * but WITHOUT ANY WARRANTY; without even the implied warranty of
- * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
- * GNU Affero General Public License for more details.
- *
- * You should have received a copy of the GNU Affero General Public License
- * along with this program.  If not, see <http://www.gnu.org/licenses/>.
- *
+ * SPDX-FileCopyrightText: 2016 Nextcloud GmbH and Nextcloud contributors
+ * SPDX-License-Identifier: AGPL-3.0-or-later
  */
 
 namespace OCA\FirstRunWizard\Tests\AppInfo;

--- a/tests/AppInfo/RoutesTest.php
+++ b/tests/AppInfo/RoutesTest.php
@@ -38,7 +38,6 @@ class RoutesTest extends TestCase {
 		$this->assertArrayHasKey('routes', $routes);
 		$this->assertIsArray($routes['routes']);
 		$this->assertSame([
-			['name' => 'Wizard#show', 'url' => '/wizard', 'verb' => 'GET'],
 			['name' => 'Wizard#disable', 'url' => '/wizard', 'verb' => 'DELETE'],
 		], $routes['routes']);
 	}

--- a/tests/Controller/WizardControllerTest.php
+++ b/tests/Controller/WizardControllerTest.php
@@ -23,11 +23,9 @@
 
 namespace OCA\FirstRunWizard\Tests\Controller;
 
-use OCA\FirstRunWizard\AppInfo\Application;
 use OCA\FirstRunWizard\Controller\WizardController;
 use OCP\AppFramework\Http;
 use OCP\AppFramework\Http\DataResponse;
-use OCP\Defaults;
 use OCP\IConfig;
 use OCP\IGroupManager;
 use OCP\IRequest;
@@ -60,8 +58,6 @@ class WizardControllerTest extends TestCase {
 			$this->createMock(IRequest::class),
 			$this->config,
 			$user,
-			\OC::$server->query(Defaults::class),
-			$this->groupManager
 		);
 	}
 
@@ -77,11 +73,6 @@ class WizardControllerTest extends TestCase {
 	 * @param string $user
 	 */
 	public function testDisable($user) {
-		$this->config->expects($this->once())
-			->method('getAppValue')
-			->with(Application::APP_ID, 'slides', 'video,values,apps,clients,final')
-			->willReturnArgument(2);
-
 		$controller = $this->getController($user);
 
 		$this->config->expects($this->once())


### PR DESCRIPTION
* Fix https://github.com/nextcloud/firstrunwizard/issues/1247

The code was not used with 28+ anymore and removed in 29+ so we also need to remove for 28.