### PR TITLE
[master] Fix npm audit

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -1527,11 +1527,12 @@
       }
     },
     "node_modules/@nextcloud/files": {
-      "version": "3.8.0",
-      "resolved": "https://registry.npmjs.org/@nextcloud/files/-/files-3.8.0.tgz",
-      "integrity": "sha512-5oi61suf2nDcXPTA4BSxl7EomJBCWrmc6ZGaokaj+jREOsSVlS+nR3ID/6eMqZSsqODpAARK56djyUPmiHOLWQ==",
+      "version": "3.9.0",
+      "resolved": "https://registry.npmjs.org/@nextcloud/files/-/files-3.9.0.tgz",
+      "integrity": "sha512-GKlD8PESRgpP3Rz7xgLbRPXvk1EKStkN8zwM3/L2Dl70g2qkUh1IdEAPZO2KlCdJPD8QxcdK4ib0KClk/ounpA==",
+      "license": "AGPL-3.0-or-later",
       "dependencies": {
-        "@nextcloud/auth": "^2.3.0",
+        "@nextcloud/auth": "^2.4.0",
         "@nextcloud/capabilities": "^1.2.0",
         "@nextcloud/l10n": "^3.1.0",
         "@nextcloud/logger": "^3.0.2",
@@ -1539,10 +1540,10 @@
         "@nextcloud/router": "^3.0.1",
         "@nextcloud/sharing": "^0.2.3",
         "cancelable-promise": "^4.3.1",
-        "is-svg": "^5.0.1",
+        "is-svg": "^5.1.0",
         "typedoc-plugin-missing-exports": "^3.0.0",
         "typescript-event-target": "^1.1.1",
-        "webdav": "^5.7.0"
+        "webdav": "^5.7.1"
       },
       "engines": {
         "node": "^20.0.0",


### PR DESCRIPTION
# Audit report

This audit fix resolves 6 of the total 10 vulnerabilities found in your project.

## Updated dependencies
* [@nextcloud/dialogs](#user-content-\@nextcloud\/dialogs)
* [@nextcloud/files](#user-content-\@nextcloud\/files)
* [@nextcloud/l10n](#user-content-\@nextcloud\/l10n)
* [@nextcloud/vue](#user-content-\@nextcloud\/vue)
* [node-gettext](#user-content-node-gettext)
* [vue-tsc](#user-content-vue-tsc)
## Fixed vulnerabilities

### @nextcloud/dialogs <a href="#user-content-\@nextcloud\/dialogs" id="\@nextcloud\/dialogs">#</a>
* Caused by vulnerable dependency:
  * [@nextcloud/files](#user-content-\@nextcloud\/files)
  * [@nextcloud/l10n](#user-content-\@nextcloud\/l10n)
  * [@nextcloud/vue](#user-content-\@nextcloud\/vue)
* Affected versions: >=2.0.0
* Package usage:
  * `node_modules/@nextcloud/dialogs`

### @nextcloud/files <a href="#user-content-\@nextcloud\/files" id="\@nextcloud\/files">#</a>
* Caused by vulnerable dependency:
  * [@nextcloud/l10n](#user-content-\@nextcloud\/l10n)
* Affected versions: >=1.1.0
* Package usage:
  * `node_modules/@nextcloud/files`

### @nextcloud/l10n <a href="#user-content-\@nextcloud\/l10n" id="\@nextcloud\/l10n">#</a>
* Caused by vulnerable dependency:
  * [node-gettext](#user-content-node-gettext)
* Affected versions: >=1.1.0
* Package usage:
  * `node_modules/@nextcloud/l10n`

### @nextcloud/vue <a href="#user-content-\@nextcloud\/vue" id="\@nextcloud\/vue">#</a>
* Caused by vulnerable dependency:
  * [@nextcloud/l10n](#user-content-\@nextcloud\/l10n)
* Affected versions: >=1.4.0
* Package usage:
  * `node_modules/@nextcloud/vue`

### node-gettext <a href="#user-content-node-gettext" id="node-gettext">#</a>
* node-gettext vulnerable to Prototype Pollution
* Severity: **moderate** (CVSS 5.9)
* Reference: [https://github.com/advisories/GHSA-g974-hxvm-x689](https://github.com/advisories/GHSA-g974-hxvm-x689)
* Affected versions: *
* Package usage:
  * `node_modules/node-gettext`

### vue-tsc <a href="#user-content-vue-tsc" id="vue-tsc">#</a>
* Caused by vulnerable dependency:
  * [@vue/language-core](#user-content-\@vue\/language-core)
* Affected versions: 1.7.0-alpha.0 - 2.0.28
* Package usage:
  * `node_modules/vue-tsc`