### PR TITLE
feat: allow to set group-restrictions

### DIFF
--- a/appinfo/info.xml
+++ b/appinfo/info.xml
@@ -20,10 +20,6 @@ The First run wizard can be customized to meet specific design goals, or to chan
 
 	<namespace>FirstRunWizard</namespace>
 
-	<types>
-		<logging/>
-	</types>
-
 	<category>tools</category>
 
 	<website>https://github.com/nextcloud/firstrunwizard</website>


### PR DESCRIPTION
Reason: a customer requested to limit the app to certain groups to limit a possible performance impact. 

Ferdinand wrote me that the logging setting allows the app to be loaded earlier. However this is not actually needed here, thus removing it.