### PR TITLE
[stable30] Fix npm audit

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -1528,9 +1528,9 @@
       }
     },
     "node_modules/@nextcloud/files": {
-      "version": "3.9.0",
-      "resolved": "https://registry.npmjs.org/@nextcloud/files/-/files-3.9.0.tgz",
-      "integrity": "sha512-GKlD8PESRgpP3Rz7xgLbRPXvk1EKStkN8zwM3/L2Dl70g2qkUh1IdEAPZO2KlCdJPD8QxcdK4ib0KClk/ounpA==",
+      "version": "3.9.1",
+      "resolved": "https://registry.npmjs.org/@nextcloud/files/-/files-3.9.1.tgz",
+      "integrity": "sha512-eureE0Hi13QhC7detUUlp5B7NjLLu1JnVLDF0yuNv/My5ETbe3SuWjulAXQ2KH3lvqVjhjgbNoEjH5wHemIG+g==",
       "license": "AGPL-3.0-or-later",
       "dependencies": {
         "@nextcloud/auth": "^2.4.0",
@@ -4324,9 +4324,9 @@
       "dev": true
     },
     "node_modules/elliptic": {
-      "version": "6.5.7",
-      "resolved": "https://registry.npmjs.org/elliptic/-/elliptic-6.5.7.tgz",
-      "integrity": "sha512-ESVCtTwiA+XhY3wyh24QqRGBoP3rEdDUl3EDUUo9tft074fi19IrdpH7hLCMMP3CIj7jb3W96rn8lt/BqIlt5Q==",
+      "version": "6.6.0",
+      "resolved": "https://registry.npmjs.org/elliptic/-/elliptic-6.6.0.tgz",
+      "integrity": "sha512-dpwoQcLc/2WLQvJvLRHKZ+f9FgOdjnq11rurqwekGQygGPsYSK29OMMD2WalatiqQ+XGFDglTNixpPfI+lpaAA==",
       "dev": true,
       "license": "MIT",
       "dependencies": {


### PR DESCRIPTION
# Audit report

This audit fix resolves 11 of the total 19 vulnerabilities found in your project.

## Updated dependencies
* [@nextcloud/dialogs](#user-content-\@nextcloud\/dialogs)
* [@nextcloud/files](#user-content-\@nextcloud\/files)
* [@nextcloud/vite-config](#user-content-\@nextcloud\/vite-config)
* [@vitejs/plugin-vue2](#user-content-\@vitejs\/plugin-vue2)
* [@vue/language-core](#user-content-\@vue\/language-core)
* [elliptic](#user-content-elliptic)
* [vite-plugin-dts](#user-content-vite-plugin-dts)
* [vue](#user-content-vue)
* [vue-resize](#user-content-vue-resize)
* [vue-template-compiler](#user-content-vue-template-compiler)
* [vue-tsc](#user-content-vue-tsc)
## Fixed vulnerabilities

### @nextcloud/dialogs <a href="#user-content-\@nextcloud\/dialogs" id="\@nextcloud\/dialogs">#</a>
* Caused by vulnerable dependency:
  * [@nextcloud/files](#user-content-\@nextcloud\/files)
  * [@nextcloud/l10n](#user-content-\@nextcloud\/l10n)
  * [@nextcloud/vue](#user-content-\@nextcloud\/vue)
  * [vue](#user-content-vue)
  * [vue-frag](#user-content-vue-frag)
* Affected versions: >=2.0.0
* Package usage:
  * `node_modules/@nextcloud/dialogs`

### @nextcloud/files <a href="#user-content-\@nextcloud\/files" id="\@nextcloud\/files">#</a>
* Caused by vulnerable dependency:
  * [@nextcloud/l10n](#user-content-\@nextcloud\/l10n)
* Affected versions: >=1.1.0
* Package usage:
  * `node_modules/@nextcloud/files`

### @nextcloud/vite-config <a href="#user-content-\@nextcloud\/vite-config" id="\@nextcloud\/vite-config">#</a>
* Caused by vulnerable dependency:
  * [@vitejs/plugin-vue2](#user-content-\@vitejs\/plugin-vue2)
  * [vite-plugin-dts](#user-content-vite-plugin-dts)
* Affected versions: *
* Package usage:
  * `node_modules/@nextcloud/vite-config`

### @vitejs/plugin-vue2 <a href="#user-content-\@vitejs\/plugin-vue2" id="\@vitejs\/plugin-vue2">#</a>
* Caused by vulnerable dependency:
  * [vue](#user-content-vue)
* Affected versions: *
* Package usage:
  * `node_modules/@vitejs/plugin-vue2`

### @vue/language-core <a href="#user-content-\@vue\/language-core" id="\@vue\/language-core">#</a>
* Caused by vulnerable dependency:
  * [vue-template-compiler](#user-content-vue-template-compiler)
* Affected versions: <=2.0.28
* Package usage:
  * `node_modules/@vue/language-core`

### elliptic <a href="#user-content-elliptic" id="elliptic">#</a>
* Valid ECDSA signatures erroneously rejected in Elliptic
* Severity: **low**
* Reference: [https://github.com/advisories/GHSA-fc9h-whq2-v747](https://github.com/advisories/GHSA-fc9h-whq2-v747)
* Affected versions: <=6.5.7
* Package usage:
  * `node_modules/elliptic`

### vite-plugin-dts <a href="#user-content-vite-plugin-dts" id="vite-plugin-dts">#</a>
* Caused by vulnerable dependency:
  * [@vue/language-core](#user-content-\@vue\/language-core)
  * [vue-tsc](#user-content-vue-tsc)
* Affected versions: 3.0.0-beta.1 - 4.0.0-beta.2
* Package usage:
  * `node_modules/vite-plugin-dts`

### vue <a href="#user-content-vue" id="vue">#</a>
* ReDoS vulnerability in vue package that is exploitable through inefficient regex evaluation in the parseHTML function
* Severity: **low** (CVSS 3.7)
* Reference: [https://github.com/advisories/GHSA-5j4c-8p2g-v4jx](https://github.com/advisories/GHSA-5j4c-8p2g-v4jx)
* Affected versions: 2.0.0-alpha.1 - 2.7.16
* Package usage:
  * `node_modules/vue`

### vue-resize <a href="#user-content-vue-resize" id="vue-resize">#</a>
* Caused by vulnerable dependency:
  * [vue](#user-content-vue)
* Affected versions: 0.4.0 - 1.0.1
* Package usage:
  * `node_modules/vue-resize`

### vue-template-compiler <a href="#user-content-vue-template-compiler" id="vue-template-compiler">#</a>
* vue-template-compiler vulnerable to client-side Cross-Site Scripting (XSS)
* Severity: **moderate** (CVSS 4.2)
* Reference: [https://github.com/advisories/GHSA-g3ch-rx76-35fx](https://github.com/advisories/GHSA-g3ch-rx76-35fx)
* Affected versions: >=2.0.0
* Package usage:
  * `node_modules/vue-template-compiler`

### vue-tsc <a href="#user-content-vue-tsc" id="vue-tsc">#</a>
* Caused by vulnerable dependency:
  * [@vue/language-core](#user-content-\@vue\/language-core)
* Affected versions: 1.7.0-alpha.0 - 2.0.28
* Package usage:
  * `node_modules/vue-tsc`