### PR TITLE
refactor: adjust code to comply with recent deprecations

### DIFF
--- a/lib/Controller/WizardController.php
+++ b/lib/Controller/WizardController.php
@@ -10,7 +10,7 @@ namespace OCA\FirstRunWizard\Controller;
 use OCP\AppFramework\Controller;
 use OCP\AppFramework\Http\Attribute\NoAdminRequired;
 use OCP\AppFramework\Http\DataResponse;
-use OCP\IConfig;
+use OCP\Config\IUserConfig;
 use OCP\IRequest;
 use OCP\ServerVersion;
 
@@ -20,7 +20,7 @@ class WizardController extends Controller {
 		string $appName,
 		IRequest $request,
 		private readonly ?string $userId,
-		private readonly IConfig $config,
+		private readonly IUserConfig $config,
 		private readonly ServerVersion $serverVersion,
 	) {
 		parent::__construct($appName, $request);
@@ -36,7 +36,7 @@ class WizardController extends Controller {
 		array_splice($version, 3);
 		/** @var list<int> $version */
 		// Set "show" to current version to only show on update
-		$this->config->setUserValue($this->userId, 'firstrunwizard', 'show', implode('.', $version));
+		$this->config->setValueString($this->userId, 'firstrunwizard', 'show', implode('.', $version));
 		return new DataResponse();
 	}
 }

--- a/lib/Notification/AppHint.php
+++ b/lib/Notification/AppHint.php
@@ -8,19 +8,19 @@
 namespace OCA\FirstRunWizard\Notification;
 
 use OCP\App\IAppManager;
-use OCP\IConfig;
+use OCP\Config\IUserConfig;
 use OCP\IGroupManager;
 use OCP\Notification\IManager as INotificationManager;
 use OCP\Notification\INotification;
 
 class AppHint {
-	public const APP_HINT_VERSION = '19';
+	public const APP_HINT_VERSION = 19;
 
 	public function __construct(
 		private readonly INotificationManager $notificationManager,
 		private readonly IGroupManager $groupManager,
 		private readonly IAppManager $appManager,
-		private readonly IConfig $config,
+		private readonly IUserConfig $userConfig,
 		private readonly ?string $userId,
 	) {
 	}
@@ -28,7 +28,7 @@ class AppHint {
 	public function sendAppHintNotifications(): void {
 		if ($this->userId !== null
 			&& $this->groupManager->isAdmin($this->userId)
-			&& $this->config->getUserValue($this->userId, 'firstrunwizard', 'apphint') !== self::APP_HINT_VERSION
+			&& $this->userConfig->getValueInt($this->userId, 'firstrunwizard', 'apphint') !== self::APP_HINT_VERSION
 		) {
 			$this->sendNotification('recognize', $this->userId);
 			$this->sendNotification('groupfolders', $this->userId);
@@ -36,14 +36,14 @@ class AppHint {
 			$this->sendNotification('deck', $this->userId);
 			$this->sendNotification('tasks', $this->userId);
 			$this->sendNotification('whiteboard', $this->userId);
-			$this->config->setUserValue($this->userId, 'firstrunwizard', 'apphint', self::APP_HINT_VERSION);
+			$this->userConfig->setValueInt($this->userId, 'firstrunwizard', 'apphint', self::APP_HINT_VERSION);
 		}
 	}
 
 	protected function sendNotification(string $app, string $user): void {
 		$notification = $this->generateNotification($app, $user);
 		if (
-			$this->config->getUserValue($this->userId, 'firstrunwizard', 'apphint') !== self::APP_HINT_VERSION
+			$this->userConfig->getValueInt($user, 'firstrunwizard', 'apphint') !== self::APP_HINT_VERSION
 			&& $this->notificationManager->getCount($notification) === 0
 			&& !$this->appManager->isEnabledForUser($app)
 		) {

--- a/tests/Controller/WizardControllerTest.php
+++ b/tests/Controller/WizardControllerTest.php
@@ -10,7 +10,7 @@ namespace OCA\FirstRunWizard\Tests\Controller;
 use OCA\FirstRunWizard\Controller\WizardController;
 use OCP\AppFramework\Http;
 use OCP\AppFramework\Http\DataResponse;
-use OCP\IConfig;
+use OCP\Config\IUserConfig;
 use OCP\IRequest;
 use OCP\ServerVersion;
 use PHPUnit\Framework\MockObject\MockObject;
@@ -24,10 +24,10 @@ use Test\TestCase;
 #[\PHPUnit\Framework\Attributes\Group('DB')]
 class WizardControllerTest extends TestCase {
 
-	protected IConfig&MockObject $config;
+	protected IUserConfig&MockObject $config;
 
 	protected function setUp(): void {
-		$this->config = $this->createMock(IConfig::class);
+		$this->config = $this->createMock(IUserConfig::class);
 	}
 
 	protected function getController(string $user = 'test'): WizardController {
@@ -52,7 +52,7 @@ class WizardControllerTest extends TestCase {
 		$controller = $this->getController($user);
 
 		$this->config->expects($this->once())
-			->method('setUserValue')
+			->method('setValueString')
 			->with($user, 'firstrunwizard', 'show');
 
 		$response = $controller->disable();


### PR DESCRIPTION
The userconfig is now a separate interface, so we need to use that.