### PR TITLE
fix: use proper AppStore route

### DIFF
--- a/lib/Notification/Notifier.php
+++ b/lib/Notification/Notifier.php
@@ -159,7 +159,7 @@ class Notifier implements INotifier {
 				break;
 		}
 		$notification
-			->setLink($this->url->linkToRouteAbsolute('settings.AppSettings.viewApps') . $appLink)
+			->setLink($this->url->linkToRouteAbsolute('appstore.Page.viewApps') . $appLink)
 			->setIcon($this->url->getAbsoluteURL($this->url->imagePath('firstrunwizard', 'apps/' . $app . '.svg')));
 		return $notification;
 	}


### PR DESCRIPTION
- resolves https://github.com/nextcloud/firstrunwizard/issues/2183

In Nextcloud 34 the appstore was split from settings into its own app, so we need to adjust the route for it.

## 🤖 AI (if applicable)

- [ ] The content of this PR was partly or fully generated using AI
